### PR TITLE
Align CLI and TUI with GUI UX improvements

### DIFF
--- a/cmd/tegata/add.go
+++ b/cmd/tegata/add.go
@@ -80,7 +80,14 @@ func newAddCmd() *cobra.Command {
 						credType, errors.ErrInvalidInput)
 				}
 
-				secret, promptErr := promptSecret("Secret: ")
+				secretPrompt := "Secret: "
+				if ct == pkgmodel.CredentialStatic {
+					secretPrompt = "Password: "
+				} else if ct == pkgmodel.CredentialChallengeResponse {
+					secretPrompt = "Shared secret key: "
+				}
+
+				secret, promptErr := promptSecret(secretPrompt)
 				if promptErr != nil {
 					return promptErr
 				}
@@ -88,9 +95,9 @@ func newAddCmd() *cobra.Command {
 				trimmedSecret := strings.TrimSpace(secret)
 
 				switch ct {
-				case pkgmodel.CredentialTOTP, pkgmodel.CredentialHOTP, pkgmodel.CredentialChallengeResponse:
+				case pkgmodel.CredentialTOTP, pkgmodel.CredentialHOTP:
 					if _, decErr := decodeBase32Secret(trimmedSecret); decErr != nil {
-						return fmt.Errorf("secret is not valid base32 — check for typos: %w", errors.ErrInvalidInput)
+						return fmt.Errorf("secret is not valid base32 — TOTP and HOTP secrets use characters A-Z and 2-7 only: %w", errors.ErrInvalidInput)
 					}
 				}
 

--- a/cmd/tegata/export.go
+++ b/cmd/tegata/export.go
@@ -73,7 +73,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		displayStrengthMeter(len(exportPass))
+		displayStrengthMeter(exportPass)
 
 		fmt.Fprint(os.Stderr, "Confirm export passphrase: ")
 		confirm, err := term.ReadPassword(int(os.Stdin.Fd()))

--- a/cmd/tegata/helpers.go
+++ b/cmd/tegata/helpers.go
@@ -117,7 +117,7 @@ func promptNewPassphrase() ([]byte, error) {
 	}
 
 	// Display strength meter.
-	displayStrengthMeter(len(pass))
+	displayStrengthMeter(pass)
 
 	// Confirm passphrase (skip for non-interactive modes).
 	if os.Getenv("TEGATA_PASSPHRASE") != "" || !term.IsTerminal(int(os.Stdin.Fd())) {
@@ -148,21 +148,57 @@ func promptNewPassphrase() ([]byte, error) {
 	return pass, nil
 }
 
+// charClasses returns the number of distinct character classes in the
+// passphrase (lowercase, uppercase, digits, symbols).
+func charClasses(pass []byte) int {
+	var lower, upper, digit, symbol bool
+	for _, b := range pass {
+		switch {
+		case b >= 'a' && b <= 'z':
+			lower = true
+		case b >= 'A' && b <= 'Z':
+			upper = true
+		case b >= '0' && b <= '9':
+			digit = true
+		default:
+			symbol = true
+		}
+	}
+	n := 0
+	if lower {
+		n++
+	}
+	if upper {
+		n++
+	}
+	if digit {
+		n++
+	}
+	if symbol {
+		n++
+	}
+	return n
+}
+
 // displayStrengthMeter prints a passphrase strength meter to stderr based on
-// character count. The meter is informational only; all lengths >= 8 are
-// accepted.
-func displayStrengthMeter(length int) {
+// length and character diversity. The meter is informational only; all lengths
+// >= 8 are accepted.
+func displayStrengthMeter(pass []byte) {
+	classes := charClasses(pass)
 	var bar, label string
-	switch {
-	case length >= 20:
-		bar = "[XXXXX]"
-		label = "Strong"
-	case length >= 12:
-		bar = "[XXX__]"
-		label = "Fair"
-	default:
+	if classes < 2 {
 		bar = "[X____]"
 		label = "Weak"
+	} else {
+		score := len(pass) + classes*3
+		switch {
+		case score >= 22:
+			bar = "[XXXXX]"
+			label = "Strong"
+		default:
+			bar = "[XXX__]"
+			label = "Fair"
+		}
 	}
 	fmt.Fprintf(os.Stderr, "  Strength: %s %s\n", bar, label)
 }

--- a/cmd/tegata/helpers.go
+++ b/cmd/tegata/helpers.go
@@ -180,26 +180,29 @@ func charClasses(pass []byte) int {
 	return n
 }
 
+// strengthLevel returns a bar and label representing passphrase strength based
+// on length and character diversity. Shared by CLI, TUI, and wizard meters so
+// the scoring algorithm stays in one place.
+func strengthLevel(pass []byte) (bar, label string) {
+	if len(pass) < 8 {
+		return "[X____]", "Too short"
+	}
+	classes := charClasses(pass)
+	if classes < 2 {
+		return "[X____]", "Weak"
+	}
+	score := len(pass) + classes*3
+	if score >= 22 {
+		return "[XXXXX]", "Strong"
+	}
+	return "[XXX__]", "Fair"
+}
+
 // displayStrengthMeter prints a passphrase strength meter to stderr based on
 // length and character diversity. The meter is informational only; all lengths
 // >= 8 are accepted.
 func displayStrengthMeter(pass []byte) {
-	classes := charClasses(pass)
-	var bar, label string
-	if classes < 2 {
-		bar = "[X____]"
-		label = "Weak"
-	} else {
-		score := len(pass) + classes*3
-		switch {
-		case score >= 22:
-			bar = "[XXXXX]"
-			label = "Strong"
-		default:
-			bar = "[XXX__]"
-			label = "Fair"
-		}
-	}
+	bar, label := strengthLevel(pass)
 	fmt.Fprintf(os.Stderr, "  Strength: %s %s\n", bar, label)
 }
 

--- a/cmd/tegata/sign.go
+++ b/cmd/tegata/sign.go
@@ -62,10 +62,11 @@ func newSignCmd() *cobra.Command {
 				return err
 			}
 
-			// Decode the base32-encoded secret stored in the credential.
+			// Try base32 first (standard for OTP secrets), fall back to raw
+			// bytes for challenge-response since users may store plain text keys.
 			secretBytes, err := decodeBase32Secret(cred.Secret)
 			if err != nil {
-				return fmt.Errorf("decoding credential secret for %q: %w", label, err)
+				secretBytes = []byte(cred.Secret)
 			}
 			defer zeroBytes(secretBytes)
 

--- a/cmd/tegata/tui_main.go
+++ b/cmd/tegata/tui_main.go
@@ -252,11 +252,8 @@ func (m model) submitCRChallenge() (tea.Model, tea.Cmd) {
 	challenge := []byte(m.crChallengeInput.Value())
 	secret, err := decodeBase32Secret(cred.Secret)
 	if err != nil {
-		m.errMsg = fmt.Sprintf("Invalid CR secret: %v", err)
-		m.crChallengeActive = false
-		m.crChallengeInput.Reset()
-		m.crChallengeInput.Blur()
-		return m, nil
+		// Fall back to raw bytes for plain text shared keys.
+		secret = []byte(cred.Secret)
 	}
 	defer zeroBytes(secret)
 

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -89,6 +89,7 @@ type model struct {
 	settingsSubFlow  string       // ""|"tags"|"passphrase"|"export"|"import"|"config"
 	settingsInput1   textinput.Model
 	settingsInput2   textinput.Model
+	settingsInput3   textinput.Model
 	settingsMsg      string
 	settingsTagIdx   int          // selected tag index in tag management
 	settingsEditMode string       // "clipboard"|"idle"|"" for config edit mode
@@ -149,6 +150,10 @@ func initialModel(vaultPath string) model {
 	settingsIn2.EchoMode = textinput.EchoPassword
 	settingsIn2.EchoCharacter = '·'
 
+	settingsIn3 := textinput.New()
+	settingsIn3.EchoMode = textinput.EchoPassword
+	settingsIn3.EchoCharacter = '·'
+
 	m := model{
 		vaultPath:        vaultPath,
 		cfg:              cfg,
@@ -163,6 +168,7 @@ func initialModel(vaultPath string) model {
 		addSecretInput:   addSecret,
 		settingsInput1:   settingsIn1,
 		settingsInput2:   settingsIn2,
+		settingsInput3:   settingsIn3,
 		credList:         credList,
 		spinner:          sp,
 		clipMgr:          clipboard.NewManager(),
@@ -324,7 +330,7 @@ func (m model) isInputFocused() bool {
 	return m.passphraseInput.Focused() || m.confirmInput.Focused() ||
 		m.crChallengeInput.Focused() ||
 		m.addLabelInput.Focused() || m.addIssuerInput.Focused() || m.addSecretInput.Focused() ||
-		m.settingsInput1.Focused() || m.settingsInput2.Focused()
+		m.settingsInput1.Focused() || m.settingsInput2.Focused() || m.settingsInput3.Focused()
 }
 
 // tickCmd returns a tea.Cmd that fires a tickMsg after one second.

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -82,7 +82,11 @@ type model struct {
 	addIssuerInput textinput.Model // issuer (optional)
 	addSecretInput textinput.Model // secret (masked)
 	addTypeIdx     int             // 0=TOTP, 1=HOTP, 2=Static, 3=CR
-	addFocusIdx    int             // 0=label, 1=issuer, 2=secret
+	addFocusIdx    int             // which add-overlay slot has focus
+	addPeriodInput textinput.Model // period in seconds (TOTP only)
+	addTagsInput   textinput.Model // comma-separated tags
+	addAlgoIdx     int             // 0=SHA1, 1=SHA256, 2=SHA512
+	addDigitsIdx   int             // 0=6, 1=8
 
 	// Settings overlay state
 	settingsMenuIdx  int          // 0-3 menu selection
@@ -143,6 +147,14 @@ func initialModel(vaultPath string) model {
 	addSecret.EchoMode = textinput.EchoPassword
 	addSecret.EchoCharacter = '·'
 
+	addPeriod := textinput.New()
+	addPeriod.Placeholder = "30"
+	addPeriod.EchoMode = textinput.EchoNormal
+
+	addTags := textinput.New()
+	addTags.Placeholder = "Tags (comma-separated)"
+	addTags.EchoMode = textinput.EchoNormal
+
 	settingsIn1 := textinput.New()
 	settingsIn1.EchoMode = textinput.EchoNormal
 
@@ -166,6 +178,8 @@ func initialModel(vaultPath string) model {
 		addLabelInput:    addLabel,
 		addIssuerInput:   addIssuer,
 		addSecretInput:   addSecret,
+		addPeriodInput:   addPeriod,
+		addTagsInput:     addTags,
 		settingsInput1:   settingsIn1,
 		settingsInput2:   settingsIn2,
 		settingsInput3:   settingsIn3,
@@ -330,6 +344,7 @@ func (m model) isInputFocused() bool {
 	return m.passphraseInput.Focused() || m.confirmInput.Focused() ||
 		m.crChallengeInput.Focused() ||
 		m.addLabelInput.Focused() || m.addIssuerInput.Focused() || m.addSecretInput.Focused() ||
+		m.addPeriodInput.Focused() || m.addTagsInput.Focused() ||
 		m.settingsInput1.Focused() || m.settingsInput2.Focused() || m.settingsInput3.Focused()
 }
 

--- a/cmd/tegata/tui_overlay_add.go
+++ b/cmd/tegata/tui_overlay_add.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -23,6 +24,27 @@ var credTypeNames = []struct {
 	{"Challenge-Resp", pkgmodel.CredentialChallengeResponse},
 }
 
+// addAlgoLabels and addAlgoValues map addAlgoIdx to display labels and
+// credential algorithm strings.
+var addAlgoLabels = []string{"SHA-1", "SHA-256", "SHA-512"}
+var addAlgoValues = []string{"SHA1", "SHA256", "SHA512"}
+
+// addDigitValues maps addDigitsIdx to digit counts.
+var addDigitValues = []int{6, 8}
+
+// Focus slot constants for the add overlay's unified focus model. Tab cycles
+// through visible slots; selector slots respond to Left/Right arrows.
+const (
+	addSlotLabel     = 0
+	addSlotIssuer    = 1
+	addSlotType      = 2
+	addSlotSecret    = 3
+	addSlotAlgorithm = 4
+	addSlotDigits    = 5
+	addSlotPeriod    = 6
+	addSlotTags      = 7
+)
+
 // resetAddOverlay clears all add-overlay input fields and resets indices.
 func (m *model) resetAddOverlay() {
 	m.addLabelInput.Reset()
@@ -31,23 +53,105 @@ func (m *model) resetAddOverlay() {
 	m.addIssuerInput.Blur()
 	m.addSecretInput.Reset()
 	m.addSecretInput.Blur()
+	m.addPeriodInput.Reset()
+	m.addPeriodInput.Blur()
+	m.addTagsInput.Reset()
+	m.addTagsInput.Blur()
 	m.addTypeIdx = 0
+	m.addAlgoIdx = 0
+	m.addDigitsIdx = 0
 	m.addFocusIdx = 0
 	m.errMsg = ""
+	m.updateSecretPlaceholder()
 }
 
-// focusAddInput blurs all add inputs, then focuses the one at addFocusIdx.
+// updateSecretPlaceholder sets the secret input placeholder text based on the
+// current credential type.
+func (m *model) updateSecretPlaceholder() {
+	switch credTypeNames[m.addTypeIdx].ctype {
+	case pkgmodel.CredentialStatic:
+		m.addSecretInput.Placeholder = "Password"
+	case pkgmodel.CredentialChallengeResponse:
+		m.addSecretInput.Placeholder = "Shared secret key"
+	default:
+		m.addSecretInput.Placeholder = "Secret (base32)"
+	}
+}
+
+// addVisibleSlots returns the ordered list of focus slot indices that are
+// visible for the current credential type.
+func (m model) addVisibleSlots() []int {
+	ct := credTypeNames[m.addTypeIdx].ctype
+	slots := []int{addSlotLabel, addSlotIssuer, addSlotType, addSlotSecret}
+	switch ct {
+	case pkgmodel.CredentialTOTP:
+		slots = append(slots, addSlotAlgorithm, addSlotDigits, addSlotPeriod)
+	case pkgmodel.CredentialHOTP:
+		slots = append(slots, addSlotAlgorithm, addSlotDigits)
+	case pkgmodel.CredentialChallengeResponse:
+		slots = append(slots, addSlotAlgorithm)
+	}
+	slots = append(slots, addSlotTags)
+	return slots
+}
+
+// addNextSlot returns the next (forward=true) or previous (forward=false)
+// visible focus slot index from the current position.
+func (m model) addNextSlot(forward bool) int {
+	slots := m.addVisibleSlots()
+	cur := 0
+	for i, s := range slots {
+		if s == m.addFocusIdx {
+			cur = i
+			break
+		}
+	}
+	if forward {
+		return slots[(cur+1)%len(slots)]
+	}
+	return slots[(cur+len(slots)-1)%len(slots)]
+}
+
+// clampAddFocus ensures addFocusIdx points to a visible slot. If the current
+// slot became invisible (e.g., after changing the credential type), it snaps
+// to the nearest preceding visible slot.
+func (m *model) clampAddFocus() {
+	slots := m.addVisibleSlots()
+	for _, s := range slots {
+		if s == m.addFocusIdx {
+			return
+		}
+	}
+	best := slots[0]
+	for _, s := range slots {
+		if s <= m.addFocusIdx {
+			best = s
+		}
+	}
+	m.addFocusIdx = best
+	m.focusAddInput()
+}
+
+// focusAddInput blurs all add text inputs, then focuses the one corresponding
+// to addFocusIdx. Selector slots (Type, Algorithm, Digits) have no text input
+// to focus — all inputs stay blurred so the user sees visual highlighting only.
 func (m *model) focusAddInput() {
 	m.addLabelInput.Blur()
 	m.addIssuerInput.Blur()
 	m.addSecretInput.Blur()
+	m.addPeriodInput.Blur()
+	m.addTagsInput.Blur()
 	switch m.addFocusIdx {
-	case 0:
+	case addSlotLabel:
 		m.addLabelInput.Focus()
-	case 1:
+	case addSlotIssuer:
 		m.addIssuerInput.Focus()
-	case 2:
+	case addSlotSecret:
 		m.addSecretInput.Focus()
+	case addSlotPeriod:
+		m.addPeriodInput.Focus()
+	case addSlotTags:
+		m.addTagsInput.Focus()
 	}
 }
 
@@ -62,21 +166,33 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case msg.Type == tea.KeyTab:
-			m.addFocusIdx = (m.addFocusIdx + 1) % 3
+			m.addFocusIdx = m.addNextSlot(true)
 			m.focusAddInput()
 			return m, nil
 
 		case msg.Type == tea.KeyShiftTab:
-			m.addFocusIdx = (m.addFocusIdx + 2) % 3
+			m.addFocusIdx = m.addNextSlot(false)
 			m.focusAddInput()
 			return m, nil
 
-		case len(msg.Runes) == 1 && msg.Runes[0] >= '1' && msg.Runes[0] <= '4':
-			if !m.addLabelInput.Focused() && !m.addIssuerInput.Focused() && !m.addSecretInput.Focused() {
-				m.addTypeIdx = int(msg.Runes[0]-'1')
+		case msg.Type == tea.KeyLeft || msg.Type == tea.KeyRight:
+			delta := 1
+			if msg.Type == tea.KeyLeft {
+				delta = -1
+			}
+			switch m.addFocusIdx {
+			case addSlotType:
+				m.addTypeIdx = (m.addTypeIdx + delta + len(credTypeNames)) % len(credTypeNames)
+				m.updateSecretPlaceholder()
+				m.clampAddFocus()
+				return m, nil
+			case addSlotAlgorithm:
+				m.addAlgoIdx = (m.addAlgoIdx + delta + len(addAlgoValues)) % len(addAlgoValues)
+				return m, nil
+			case addSlotDigits:
+				m.addDigitsIdx = (m.addDigitsIdx + delta + len(addDigitValues)) % len(addDigitValues)
 				return m, nil
 			}
-			// Digit is being typed into an active text field — fall through to delegate.
 
 		case msg.Type == tea.KeyEnter:
 			labelVal := m.addLabelInput.Value()
@@ -97,6 +213,22 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 						break
 					}
 				}
+				for i, a := range addAlgoValues {
+					if strings.EqualFold(a, cred.Algorithm) {
+						m.addAlgoIdx = i
+						break
+					}
+				}
+				for i, d := range addDigitValues {
+					if d == cred.Digits {
+						m.addDigitsIdx = i
+						break
+					}
+				}
+				if cred.Period > 0 {
+					m.addPeriodInput.SetValue(strconv.Itoa(cred.Period))
+				}
+				m.updateSecretPlaceholder()
 				m.errMsg = ""
 				return m, nil
 			}
@@ -108,7 +240,6 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			// Validate base32 encoding for TOTP and HOTP secrets.
-			// Challenge-response allows plain text shared keys.
 			ct := credTypeNames[m.addTypeIdx]
 			switch ct.ctype {
 			case pkgmodel.CredentialTOTP, pkgmodel.CredentialHOTP:
@@ -118,15 +249,43 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
+			// Read algorithm and digits from selectors.
+			algo := addAlgoValues[m.addAlgoIdx]
+			digits := addDigitValues[m.addDigitsIdx]
+
+			// Parse period for TOTP credentials.
+			period := 30
+			if ct.ctype == pkgmodel.CredentialTOTP {
+				if v := strings.TrimSpace(m.addPeriodInput.Value()); v != "" {
+					p, err := strconv.Atoi(v)
+					if err != nil || p < 15 || p > 120 {
+						m.errMsg = "Period must be between 15 and 120 seconds"
+						return m, nil
+					}
+					period = p
+				}
+			}
+
+			// Parse comma-separated tags.
+			var tags []string
+			if raw := strings.TrimSpace(m.addTagsInput.Value()); raw != "" {
+				for _, t := range strings.Split(raw, ",") {
+					if t = strings.TrimSpace(t); t != "" {
+						tags = append(tags, t)
+					}
+				}
+			}
+
 			// Build credential from inputs.
 			cred := pkgmodel.Credential{
 				Label:     labelVal,
 				Issuer:    m.addIssuerInput.Value(),
 				Type:      ct.ctype,
 				Secret:    m.addSecretInput.Value(),
-				Algorithm: "SHA1",
-				Digits:    6,
-				Period:    30,
+				Algorithm: algo,
+				Digits:    digits,
+				Period:    period,
+				Tags:      tags,
 			}
 
 			if m.vaultMgr == nil {
@@ -139,7 +298,6 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			// Refresh credential list and select the newly added item.
 			m = refreshCredList(m, labelVal)
 
 			label := labelVal
@@ -150,45 +308,69 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// Delegate to the focused text input.
+	// Delegate to the focused text input. Selector slots (2, 4, 5) have no
+	// text input — key events are silently dropped for those.
 	var cmd tea.Cmd
 	switch m.addFocusIdx {
-	case 0:
+	case addSlotLabel:
 		m.addLabelInput, cmd = m.addLabelInput.Update(msg)
-	case 1:
+	case addSlotIssuer:
 		m.addIssuerInput, cmd = m.addIssuerInput.Update(msg)
-	case 2:
+	case addSlotSecret:
 		m.addSecretInput, cmd = m.addSecretInput.Update(msg)
+	case addSlotPeriod:
+		m.addPeriodInput, cmd = m.addPeriodInput.Update(msg)
+	case addSlotTags:
+		m.addTagsInput, cmd = m.addTagsInput.Update(msg)
 	}
 	return m, cmd
 }
 
+// addLabelWidth is the column width for field labels in the add overlay.
+const addLabelWidth = 13
+
 // viewOverlayAdd renders the add-credential overlay.
 func (m model) viewOverlayAdd() string {
+	ct := credTypeNames[m.addTypeIdx]
 	var lines []string
 	lines = append(lines, titleStyle.Render("Add Credential"))
 	lines = append(lines, "")
-	lines = append(lines, "Label:   "+m.addLabelInput.View())
-	lines = append(lines, "Issuer:  "+m.addIssuerInput.View()+" (optional)")
-	ct := credTypeNames[m.addTypeIdx]
-	secretLabel := "Secret:"
-	if ct.ctype == pkgmodel.CredentialStatic {
-		secretLabel = "Password:"
-	}
-	lines = append(lines, fmt.Sprintf("%-9s %s", secretLabel, m.addSecretInput.View()))
-	lines = append(lines, "")
+
+	lines = append(lines, fmt.Sprintf("%-*s%s", addLabelWidth, "Label:", m.addLabelInput.View()))
+	lines = append(lines, fmt.Sprintf("%-*s%s %s", addLabelWidth, "Issuer:", m.addIssuerInput.View(), helpBarStyle.Render("(optional)")))
 
 	// Type selector row.
-	var typeRow []string
-	for i, ct := range credTypeNames {
-		key := fmt.Sprintf("[%d]", i+1)
-		if m.addTypeIdx == i {
-			typeRow = append(typeRow, successStyle.Render(key+" "+ct.label))
-		} else {
-			typeRow = append(typeRow, key+" "+ct.label)
-		}
+	lines = append(lines, renderAddSelector("Type:", addSlotType, m.addFocusIdx, m.addTypeIdx, credTypeDisplayLabels()))
+
+	// Secret row with type-dependent label.
+	var secretLabel string
+	switch ct.ctype {
+	case pkgmodel.CredentialStatic:
+		secretLabel = "Password:"
+	case pkgmodel.CredentialChallengeResponse:
+		secretLabel = "Shared secret key:"
+	default:
+		secretLabel = "Secret:"
 	}
-	lines = append(lines, "Type:    "+strings.Join(typeRow, "  "))
+	lines = append(lines, fmt.Sprintf("%-*s%s", addLabelWidth, secretLabel, m.addSecretInput.View()))
+
+	// Algorithm selector — hidden for Static.
+	if ct.ctype != pkgmodel.CredentialStatic {
+		lines = append(lines, renderAddSelector("Algorithm:", addSlotAlgorithm, m.addFocusIdx, m.addAlgoIdx, addAlgoLabels))
+	}
+
+	// Digits selector — TOTP and HOTP only.
+	if ct.ctype == pkgmodel.CredentialTOTP || ct.ctype == pkgmodel.CredentialHOTP {
+		lines = append(lines, renderAddSelector("Digits:", addSlotDigits, m.addFocusIdx, m.addDigitsIdx, []string{"6", "8"}))
+	}
+
+	// Period text input — TOTP only.
+	if ct.ctype == pkgmodel.CredentialTOTP {
+		lines = append(lines, fmt.Sprintf("%-*s%s %s", addLabelWidth, "Period:", m.addPeriodInput.View(), helpBarStyle.Render("seconds")))
+	}
+
+	// Tags text input.
+	lines = append(lines, fmt.Sprintf("%-*s%s %s", addLabelWidth, "Tags:", m.addTagsInput.View(), helpBarStyle.Render("(optional)")))
 
 	if m.errMsg != "" {
 		lines = append(lines, "")
@@ -196,11 +378,40 @@ func (m model) viewOverlayAdd() string {
 	}
 
 	lines = append(lines, "")
-	lines = append(lines, helpBarStyle.Render("[Tab/Shift+Tab] Navigate  [Enter] Save  [Esc] Cancel"))
+	lines = append(lines, helpBarStyle.Render("[Tab] Navigate  [\u2190/\u2192] Change  [Enter] Save  [Esc] Cancel"))
 
 	content := strings.Join(lines, "\n")
 	overlay := overlayBoxStyle.Render(content)
 	return overlayOnBackground(overlay, m.width, m.height)
+}
+
+// credTypeDisplayLabels returns the display labels for credential types.
+func credTypeDisplayLabels() []string {
+	labels := make([]string, len(credTypeNames))
+	for i, ct := range credTypeNames {
+		labels[i] = ct.label
+	}
+	return labels
+}
+
+// renderAddSelector renders a label + selectable options row. The selected
+// option is highlighted in green. When the selector has focus, left/right
+// arrows flank the selected option.
+func renderAddSelector(label string, slot, focusIdx, selectedIdx int, options []string) string {
+	focused := focusIdx == slot
+	var parts []string
+	for i, opt := range options {
+		if i == selectedIdx {
+			if focused {
+				parts = append(parts, successStyle.Render("\u2190 "+opt+" \u2192"))
+			} else {
+				parts = append(parts, successStyle.Render(opt))
+			}
+		} else {
+			parts = append(parts, opt)
+		}
+	}
+	return fmt.Sprintf("%-*s%s", addLabelWidth, label, strings.Join(parts, "  "))
 }
 
 // updateOverlayRemove handles key events in stateOverlayRemove.

--- a/cmd/tegata/tui_overlay_add.go
+++ b/cmd/tegata/tui_overlay_add.go
@@ -107,13 +107,13 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			// Validate base32 encoding for credential types that require it,
-			// matching the CLI add command's validation.
+			// Validate base32 encoding for TOTP and HOTP secrets.
+			// Challenge-response allows plain text shared keys.
 			ct := credTypeNames[m.addTypeIdx]
 			switch ct.ctype {
-			case pkgmodel.CredentialTOTP, pkgmodel.CredentialHOTP, pkgmodel.CredentialChallengeResponse:
+			case pkgmodel.CredentialTOTP, pkgmodel.CredentialHOTP:
 				if _, err := decodeBase32Secret(m.addSecretInput.Value()); err != nil {
-					m.errMsg = "Secret is not valid base32 — check for typos"
+					m.errMsg = "Secret is not valid base32 — TOTP and HOTP use A-Z and 2-7 only"
 					return m, nil
 				}
 			}
@@ -170,7 +170,12 @@ func (m model) viewOverlayAdd() string {
 	lines = append(lines, "")
 	lines = append(lines, "Label:   "+m.addLabelInput.View())
 	lines = append(lines, "Issuer:  "+m.addIssuerInput.View()+" (optional)")
-	lines = append(lines, "Secret:  "+m.addSecretInput.View())
+	ct := credTypeNames[m.addTypeIdx]
+	secretLabel := "Secret:  "
+	if ct.ctype == pkgmodel.CredentialStatic {
+		secretLabel = "Password:"
+	}
+	lines = append(lines, secretLabel+" "+m.addSecretInput.View())
 	lines = append(lines, "")
 
 	// Type selector row.

--- a/cmd/tegata/tui_overlay_add.go
+++ b/cmd/tegata/tui_overlay_add.go
@@ -171,11 +171,11 @@ func (m model) viewOverlayAdd() string {
 	lines = append(lines, "Label:   "+m.addLabelInput.View())
 	lines = append(lines, "Issuer:  "+m.addIssuerInput.View()+" (optional)")
 	ct := credTypeNames[m.addTypeIdx]
-	secretLabel := "Secret:  "
+	secretLabel := "Secret:"
 	if ct.ctype == pkgmodel.CredentialStatic {
 		secretLabel = "Password:"
 	}
-	lines = append(lines, secretLabel+" "+m.addSecretInput.View())
+	lines = append(lines, fmt.Sprintf("%-9s %s", secretLabel, m.addSecretInput.View()))
 	lines = append(lines, "")
 
 	// Type selector row.

--- a/cmd/tegata/tui_overlay_settings.go
+++ b/cmd/tegata/tui_overlay_settings.go
@@ -15,12 +15,13 @@ import (
 	"github.com/josh-wong/tegata/internal/vault"
 )
 
-// settingsMenuItems lists the four settings menu options in order.
+// settingsMenuItems lists the settings menu options in order.
 var settingsMenuItems = []string{
 	"Tag management",
 	"Change passphrase",
 	"Export / import",
 	"Config settings",
+	"Verify recovery key",
 }
 
 // resetSettingsOverlay resets all settings overlay state to defaults.
@@ -52,6 +53,8 @@ func (m model) updateOverlaySettings(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateSettingsImport(msg)
 	case "config":
 		return m.updateSettingsConfig(msg)
+	case "recovery":
+		return m.updateSettingsRecovery(msg)
 	default:
 		return m.updateSettingsMenu(msg)
 	}
@@ -116,6 +119,10 @@ func (m model) updateSettingsMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.settingsInput2.Placeholder = "Export passphrase"
 				m.settingsInput2.EchoMode = textinput.EchoPassword
 				m.settingsInput2.EchoCharacter = '·'
+				m.settingsInput3.Reset()
+				m.settingsInput3.Placeholder = "Confirm passphrase"
+				m.settingsInput3.EchoMode = textinput.EchoPassword
+				m.settingsInput3.EchoCharacter = '·'
 				m.settingsInput1.Focus()
 				m.settingsMsg = ""
 			case 3:
@@ -124,6 +131,13 @@ func (m model) updateSettingsMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.settingsEditMode = ""
 				m.settingsInput1.Reset()
 				m.settingsInput1.Blur()
+			case 4:
+				m.settingsSubFlow = "recovery"
+				m.settingsInput1.Reset()
+				m.settingsInput1.Placeholder = "Recovery key"
+				m.settingsInput1.EchoMode = textinput.EchoNormal
+				m.settingsInput1.Focus()
+				m.settingsMsg = ""
 			}
 			return m, nil
 		}
@@ -327,6 +341,7 @@ func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // updateSettingsExport handles the export sub-flow.
+// Input1 = file path, Input2 = export passphrase, Input3 = confirm passphrase.
 func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -337,6 +352,8 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.settingsInput1.Blur()
 			m.settingsInput2.Reset()
 			m.settingsInput2.Blur()
+			m.settingsInput3.Reset()
+			m.settingsInput3.Blur()
 			m.settingsMsg = ""
 			return m, nil
 
@@ -344,8 +361,11 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.settingsInput1.Focused() {
 				m.settingsInput1.Blur()
 				m.settingsInput2.Focus()
-			} else {
+			} else if m.settingsInput2.Focused() {
 				m.settingsInput2.Blur()
+				m.settingsInput3.Focus()
+			} else {
+				m.settingsInput3.Blur()
 				m.settingsInput1.Focus()
 			}
 			return m, nil
@@ -361,14 +381,27 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.settingsInput2.EchoMode = textinput.EchoPassword
 			m.settingsInput2.EchoCharacter = '·'
 			m.settingsInput2.Blur()
+			m.settingsInput3.Reset()
+			m.settingsInput3.Blur()
 			m.settingsInput1.Focus()
 			m.settingsMsg = ""
 			return m, nil
 
 		case tea.KeyEnter:
 			path := m.settingsInput1.Value()
-			if path == "" || m.settingsInput2.Value() == "" {
+			passVal := m.settingsInput2.Value()
+			confirmVal := m.settingsInput3.Value()
+
+			if path == "" || passVal == "" {
 				m.settingsMsg = "File path and passphrase are required"
+				return m, nil
+			}
+			if len(passVal) < 8 {
+				m.settingsMsg = "Export passphrase must be at least 8 characters"
+				return m, nil
+			}
+			if passVal != confirmVal {
+				m.settingsMsg = "Passphrases do not match"
 				return m, nil
 			}
 			if m.vaultMgr == nil {
@@ -376,7 +409,7 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			pp := []byte(m.settingsInput2.Value())
+			pp := []byte(passVal)
 			defer zeroBytes(pp)
 
 			data, err := m.vaultMgr.ExportCredentials(pp)
@@ -384,6 +417,7 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.settingsMsg = fmt.Sprintf("Export failed: %v", err)
 				return m, nil
 			}
+			defer zeroBytes(data)
 
 			if err := os.WriteFile(path, data, 0600); err != nil {
 				m.settingsMsg = fmt.Sprintf("Write failed: %v", err)
@@ -394,6 +428,8 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.settingsInput1.Blur()
 			m.settingsInput2.Reset()
 			m.settingsInput2.Blur()
+			m.settingsInput3.Reset()
+			m.settingsInput3.Blur()
 			m.settingsMsg = "Exported to " + path
 			m.settingsSubFlow = ""
 			return m, nil
@@ -403,8 +439,10 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	if m.settingsInput1.Focused() {
 		m.settingsInput1, cmd = m.settingsInput1.Update(msg)
-	} else {
+	} else if m.settingsInput2.Focused() {
 		m.settingsInput2, cmd = m.settingsInput2.Update(msg)
+	} else {
+		m.settingsInput3, cmd = m.settingsInput3.Update(msg)
 	}
 	return m, cmd
 }
@@ -562,13 +600,14 @@ func (m model) viewOverlaySettings() string {
 	case "passphrase":
 		content = m.viewSettingsPassphrase()
 	case "export":
-		content = m.viewSettingsExportImport("Export credentials", "Export file path", "Export passphrase",
-			"[Tab] Next  [Enter] Export  [F1] Switch to Import  [Esc] Cancel")
+		content = m.viewSettingsExport()
 	case "import":
 		content = m.viewSettingsExportImport("Import credentials", "Import file path", "Import passphrase",
 			"[Tab] Next  [Enter] Import  [Esc] Cancel")
 	case "config":
 		content = m.viewSettingsConfig()
+	case "recovery":
+		content = m.viewSettingsRecovery()
 	default:
 		content = m.viewSettingsMenu()
 	}
@@ -666,6 +705,29 @@ func tuiStrengthLabel(pass []byte) string {
 	return bar + " " + label
 }
 
+// viewSettingsExport renders the export sub-flow with passphrase confirmation
+// and strength meter.
+func (m model) viewSettingsExport() string {
+	var lines []string
+	lines = append(lines, titleStyle.Render("Export credentials"))
+	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("%-20s%s", "Export file path:", m.settingsInput1.View()))
+	lines = append(lines, fmt.Sprintf("%-20s%s", "Export passphrase:", m.settingsInput2.View()))
+	if pp := m.settingsInput2.Value(); len(pp) >= 8 {
+		ppBytes := []byte(pp)
+		lines = append(lines, fmt.Sprintf("%-20s%s", "", tuiStrengthLabel(ppBytes)))
+		zeroBytes(ppBytes)
+	}
+	lines = append(lines, fmt.Sprintf("%-20s%s", "Confirm passphrase:", m.settingsInput3.View()))
+	if m.settingsMsg != "" {
+		lines = append(lines, "")
+		lines = append(lines, errorStyle.Render(m.settingsMsg))
+	}
+	lines = append(lines, "")
+	lines = append(lines, helpBarStyle.Render("[Tab] Next  [Enter] Export  [F1] Import  [Esc] Cancel"))
+	return strings.Join(lines, "\n")
+}
+
 // viewSettingsExportImport renders the export or import sub-flow form.
 func (m model) viewSettingsExportImport(title, label1, label2, help string) string {
 	var lines []string
@@ -679,6 +741,75 @@ func (m model) viewSettingsExportImport(title, label1, label2, help string) stri
 	}
 	lines = append(lines, "")
 	lines = append(lines, helpBarStyle.Render(help))
+	return strings.Join(lines, "\n")
+}
+
+// updateSettingsRecovery handles the recovery key verification sub-flow.
+func (m model) updateSettingsRecovery(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEsc:
+			m.settingsSubFlow = ""
+			m.settingsInput1.Reset()
+			m.settingsInput1.Blur()
+			m.settingsMsg = ""
+			return m, nil
+
+		case tea.KeyEnter:
+			keyStr := strings.TrimSpace(m.settingsInput1.Value())
+			if keyStr == "" {
+				m.settingsMsg = "Recovery key is required"
+				return m, nil
+			}
+			rawKey, err := decodeBase32Secret(keyStr)
+			if err != nil {
+				m.settingsMsg = "Could not decode recovery key — check for typos"
+				return m, nil
+			}
+			defer zeroBytes(rawKey)
+
+			if m.vaultMgr == nil {
+				m.settingsMsg = "Vault not unlocked"
+				return m, nil
+			}
+			ok, err := m.vaultMgr.VerifyRecoveryKey(rawKey)
+			if err != nil {
+				m.settingsMsg = fmt.Sprintf("Error: %v", err)
+				return m, nil
+			}
+			if ok {
+				m.settingsMsg = "Recovery key is valid"
+			} else {
+				m.settingsMsg = "Recovery key is invalid — check for typos, dashes, and case"
+			}
+			m.settingsInput1.Reset()
+			m.settingsInput1.Blur()
+			return m, nil
+		}
+	}
+
+	var cmd tea.Cmd
+	m.settingsInput1, cmd = m.settingsInput1.Update(msg)
+	return m, cmd
+}
+
+// viewSettingsRecovery renders the recovery key verification sub-flow.
+func (m model) viewSettingsRecovery() string {
+	var lines []string
+	lines = append(lines, titleStyle.Render("Verify recovery key"))
+	lines = append(lines, "")
+	lines = append(lines, "Recovery key: "+m.settingsInput1.View())
+	if m.settingsMsg != "" {
+		lines = append(lines, "")
+		if strings.Contains(m.settingsMsg, "valid") && !strings.Contains(m.settingsMsg, "invalid") {
+			lines = append(lines, successStyle.Render(m.settingsMsg))
+		} else {
+			lines = append(lines, errorStyle.Render(m.settingsMsg))
+		}
+	}
+	lines = append(lines, "")
+	lines = append(lines, helpBarStyle.Render("[Enter] Verify  [Esc] Cancel"))
 	return strings.Join(lines, "\n")
 }
 

--- a/cmd/tegata/tui_overlay_settings.go
+++ b/cmd/tegata/tui_overlay_settings.go
@@ -32,6 +32,8 @@ func (m *model) resetSettingsOverlay() {
 	m.settingsInput1.EchoMode = textinput.EchoNormal
 	m.settingsInput2.Reset()
 	m.settingsInput2.Blur()
+	m.settingsInput3.Reset()
+	m.settingsInput3.Blur()
 	m.settingsMsg = ""
 	m.settingsTagIdx = 0
 	m.settingsEditMode = ""
@@ -640,12 +642,14 @@ func (m model) viewSettingsPassphrase() string {
 	var lines []string
 	lines = append(lines, titleStyle.Render("Change passphrase"))
 	lines = append(lines, "")
-	lines = append(lines, "Current passphrase:     "+m.settingsInput1.View())
-	lines = append(lines, "New passphrase:         "+m.settingsInput2.View())
+	lines = append(lines, fmt.Sprintf("%-24s%s", "Current passphrase:", m.settingsInput1.View()))
+	lines = append(lines, fmt.Sprintf("%-24s%s", "New passphrase:", m.settingsInput2.View()))
 	if newPP := m.settingsInput2.Value(); len(newPP) >= 8 {
-		lines = append(lines, "                        "+tuiStrengthLabel([]byte(newPP)))
+		ppBytes := []byte(newPP)
+		lines = append(lines, fmt.Sprintf("%-24s%s", "", tuiStrengthLabel(ppBytes)))
+		zeroBytes(ppBytes)
 	}
-	lines = append(lines, "Confirm new passphrase: "+m.settingsInput3.View())
+	lines = append(lines, fmt.Sprintf("%-24s%s", "Confirm new passphrase:", m.settingsInput3.View()))
 	if m.settingsMsg != "" {
 		lines = append(lines, "")
 		lines = append(lines, errorStyle.Render(m.settingsMsg))
@@ -655,18 +659,11 @@ func (m model) viewSettingsPassphrase() string {
 	return strings.Join(lines, "\n")
 }
 
-// tuiStrengthLabel returns a strength label for the passphrase, matching the
-// CLI displayStrengthMeter logic.
+// tuiStrengthLabel returns a strength label for the passphrase, using the
+// shared strengthLevel scoring to stay in sync with the CLI meter.
 func tuiStrengthLabel(pass []byte) string {
-	classes := charClasses(pass)
-	if classes < 2 {
-		return "[X____] Weak"
-	}
-	score := len(pass) + classes*3
-	if score >= 22 {
-		return "[XXXXX] Strong"
-	}
-	return "[XXX__] Fair"
+	bar, label := strengthLevel(pass)
+	return bar + " " + label
 }
 
 // viewSettingsExportImport renders the export or import sub-flow form.

--- a/cmd/tegata/tui_overlay_settings.go
+++ b/cmd/tegata/tui_overlay_settings.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/josh-wong/tegata/internal/config"
+	"github.com/josh-wong/tegata/internal/vault"
 )
 
 // settingsMenuItems lists the four settings menu options in order.
@@ -89,13 +90,17 @@ func (m model) updateSettingsMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case 1:
 				m.settingsSubFlow = "passphrase"
 				m.settingsInput1.Reset()
-				m.settingsInput1.Placeholder = "New passphrase"
+				m.settingsInput1.Placeholder = "Current passphrase"
 				m.settingsInput1.EchoMode = textinput.EchoPassword
 				m.settingsInput1.EchoCharacter = '·'
 				m.settingsInput2.Reset()
-				m.settingsInput2.Placeholder = "Confirm passphrase"
+				m.settingsInput2.Placeholder = "New passphrase"
 				m.settingsInput2.EchoMode = textinput.EchoPassword
 				m.settingsInput2.EchoCharacter = '·'
+				m.settingsInput3.Reset()
+				m.settingsInput3.Placeholder = "Confirm new passphrase"
+				m.settingsInput3.EchoMode = textinput.EchoPassword
+				m.settingsInput3.EchoCharacter = '·'
 				m.settingsInput1.Focus()
 				m.settingsMsg = ""
 			case 2:
@@ -222,6 +227,7 @@ func (m model) updateSettingsTags(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // updateSettingsPassphrase handles the change-passphrase sub-flow.
+// Input1 = current passphrase, Input2 = new passphrase, Input3 = confirm.
 func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -232,6 +238,8 @@ func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.settingsInput1.Blur()
 			m.settingsInput2.Reset()
 			m.settingsInput2.Blur()
+			m.settingsInput3.Reset()
+			m.settingsInput3.Blur()
 			m.settingsMsg = ""
 			return m, nil
 
@@ -239,22 +247,26 @@ func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.settingsInput1.Focused() {
 				m.settingsInput1.Blur()
 				m.settingsInput2.Focus()
-			} else {
+			} else if m.settingsInput2.Focused() {
 				m.settingsInput2.Blur()
+				m.settingsInput3.Focus()
+			} else {
+				m.settingsInput3.Blur()
 				m.settingsInput1.Focus()
 			}
 			return m, nil
 
 		case tea.KeyEnter:
-			pp1 := m.settingsInput1.Value()
-			pp2 := m.settingsInput2.Value()
+			current := m.settingsInput1.Value()
+			newPP := m.settingsInput2.Value()
+			confirm := m.settingsInput3.Value()
 
-			if pp1 != pp2 {
-				m.settingsMsg = "Passphrases do not match"
+			if newPP != confirm {
+				m.settingsMsg = "New passphrases do not match"
 				return m, nil
 			}
-			if len(pp1) < 8 {
-				m.settingsMsg = "Passphrase must be at least 8 characters"
+			if len(newPP) < 8 {
+				m.settingsMsg = "New passphrase must be at least 8 characters"
 				return m, nil
 			}
 			if m.vaultMgr == nil {
@@ -262,7 +274,22 @@ func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			pp := []byte(pp1)
+			// Verify current passphrase.
+			currentBytes := []byte(current)
+			defer zeroBytes(currentBytes)
+			verifier, err := vault.Open(m.vaultPath)
+			if err != nil {
+				m.settingsMsg = fmt.Sprintf("Error: %v", err)
+				return m, nil
+			}
+			if err := verifier.Unlock(currentBytes); err != nil {
+				verifier.Close()
+				m.settingsMsg = "Current passphrase is incorrect"
+				return m, nil
+			}
+			verifier.Close()
+
+			pp := []byte(newPP)
 			defer zeroBytes(pp)
 
 			if err := m.vaultMgr.ChangePassphrase(pp); err != nil {
@@ -278,6 +305,8 @@ func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.settingsInput1.Blur()
 			m.settingsInput2.Reset()
 			m.settingsInput2.Blur()
+			m.settingsInput3.Reset()
+			m.settingsInput3.Blur()
 			m.settingsMsg = "Passphrase changed."
 			m.settingsSubFlow = ""
 			return m, nil
@@ -287,8 +316,10 @@ func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	if m.settingsInput1.Focused() {
 		m.settingsInput1, cmd = m.settingsInput1.Update(msg)
-	} else {
+	} else if m.settingsInput2.Focused() {
 		m.settingsInput2, cmd = m.settingsInput2.Update(msg)
+	} else {
+		m.settingsInput3, cmd = m.settingsInput3.Update(msg)
 	}
 	return m, cmd
 }
@@ -609,8 +640,12 @@ func (m model) viewSettingsPassphrase() string {
 	var lines []string
 	lines = append(lines, titleStyle.Render("Change passphrase"))
 	lines = append(lines, "")
-	lines = append(lines, "New passphrase:     "+m.settingsInput1.View())
-	lines = append(lines, "Confirm passphrase: "+m.settingsInput2.View())
+	lines = append(lines, "Current passphrase:     "+m.settingsInput1.View())
+	lines = append(lines, "New passphrase:         "+m.settingsInput2.View())
+	if newPP := m.settingsInput2.Value(); len(newPP) >= 8 {
+		lines = append(lines, "                        "+tuiStrengthLabel([]byte(newPP)))
+	}
+	lines = append(lines, "Confirm new passphrase: "+m.settingsInput3.View())
 	if m.settingsMsg != "" {
 		lines = append(lines, "")
 		lines = append(lines, errorStyle.Render(m.settingsMsg))
@@ -618,6 +653,20 @@ func (m model) viewSettingsPassphrase() string {
 	lines = append(lines, "")
 	lines = append(lines, helpBarStyle.Render("[Tab] Next  [Enter] Confirm  [Esc] Cancel"))
 	return strings.Join(lines, "\n")
+}
+
+// tuiStrengthLabel returns a strength label for the passphrase, matching the
+// CLI displayStrengthMeter logic.
+func tuiStrengthLabel(pass []byte) string {
+	classes := charClasses(pass)
+	if classes < 2 {
+		return "[X____] Weak"
+	}
+	score := len(pass) + classes*3
+	if score >= 22 {
+		return "[XXXXX] Strong"
+	}
+	return "[XXX__] Fair"
 }
 
 // viewSettingsExportImport renders the export or import sub-flow form.

--- a/cmd/tegata/tui_wizard.go
+++ b/cmd/tegata/tui_wizard.go
@@ -306,7 +306,9 @@ func (m model) viewWizardWelcome() string {
 
 // viewWizardPassphrase renders step 2/4.
 func (m model) viewWizardPassphrase() string {
-	strength := strengthLabel(len(m.passphraseInput.Value()))
+	ppBytes := []byte(m.passphraseInput.Value())
+	strength := strengthLabel(ppBytes)
+	zeroBytes(ppBytes)
 	content := titleStyle.Render("Step 2/4: Set passphrase") + "\n\n" +
 		m.passphraseInput.View() + "\n" +
 		m.confirmInput.View() + "\n\n" +
@@ -349,15 +351,16 @@ func (m model) viewWizardAddCredential() string {
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
 }
 
-// strengthLabel returns a human-readable passphrase strength label based on
-// character count. Informational only; no minimum is enforced here.
-func strengthLabel(length int) string {
-	switch {
-	case length >= 20:
-		return successStyle.Render("Strong")
-	case length >= 12:
-		return "Fair"
+// strengthLabel returns a styled passphrase strength label using the shared
+// strengthLevel scoring. Informational only; no minimum is enforced here.
+func strengthLabel(pass []byte) string {
+	_, label := strengthLevel(pass)
+	switch label {
+	case "Strong":
+		return successStyle.Render(label)
+	case "Weak", "Too short":
+		return errorStyle.Render(label)
 	default:
-		return errorStyle.Render("Weak")
+		return label
 	}
 }


### PR DESCRIPTION
## Summary

This PR aligns the CLI and TUI interfaces with UX and security improvements introduced in the desktop GUI, fixing cross-interface credential compatibility and a TUI security gap.

## Related issues or PRs

- Resolves #8
- Relates to #7

## Changes made

- TUI passphrase change now verifies the current passphrase before allowing the change
- CLI and TUI challenge-response signing falls back to raw bytes when base32 decoding fails, so CR credentials created with plain text secrets in the GUI work in all interfaces
- CLI and TUI no longer reject plain text secrets when adding challenge-response credentials (base32 validation limited to TOTP/HOTP only)
- CLI prompts "Password:" for static credentials and "Shared secret key:" for challenge-response instead of the generic "Secret:"
- TUI add overlay shows "Password:" label for static credentials
- CLI and TUI strength meters now factor in character diversity (uppercase, lowercase, digits, symbols) alongside length, matching the GUI scoring algorithm
- TUI passphrase change displays a live strength meter for the new passphrase

## Technical implementation

- **Approach:** Minimal changes to CLI and TUI code to match behavior already implemented in the GUI adapter, reusing the same `charClasses()` scoring function across all interfaces
- **Key components modified:** `cmd/tegata/sign.go`, `cmd/tegata/add.go`, `cmd/tegata/helpers.go`, `cmd/tegata/export.go`, `cmd/tegata/tui_main.go`, `cmd/tegata/tui_overlay_add.go`, `cmd/tegata/tui_overlay_settings.go`, `cmd/tegata/tui_model.go`
- **Dependencies added/removed:** None
- **Design patterns used:** Same open-and-unlock verification pattern used in the GUI adapter for TUI passphrase change; same base32-with-raw-fallback pattern for CR signing

## Testing performed

- [ ] Builds successfully on Linux (amd64)
- [ ] Builds successfully on macOS (if applicable)
- [ ] Builds successfully on Windows (if applicable)
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] CLI commands tested manually with expected inputs
- [ ] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable)
- [ ] ScalarDL integration tested (if applicable)
- [ ] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [x] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes

## Additional context

- The `displayStrengthMeter()` function signature changed from `int` to `[]byte` to support character diversity analysis — `export.go` was updated to match
- The TUI model gained a `settingsInput3` field to support the three-field passphrase change flow (current, new, confirm)
- CLI and TUI base32 validation error messages now match the improved wording from the GUI