### PR TITLE
Add ignore files to reduce token usage during development

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,50 @@
+# Build artifacts
+bin/
+dist/
+build/
+*.o
+*.a
+*.so
+*.dll
+*.dylib
+
+# Generated code
+*.pb.go
+*.pb.gw.go
+
+# Dependencies
+vendor/
+go.sum
+
+# Test data and secrets
+*.vault
+*.queue
+.env
+.env.local
+.env.*.local
+
+# IDE and editor config
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Docker and build artifacts
+docker-compose.override.yml
+Dockerfile.dev
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.log
+
+# Large binaries and executables
+/tegata
+/tegata.exe
+/tegata-darwin
+
+# CI/CD artifacts
+.actrc

--- a/.copilotignore
+++ b/.copilotignore
@@ -1,0 +1,50 @@
+# Build artifacts
+bin/
+dist/
+build/
+*.o
+*.a
+*.so
+*.dll
+*.dylib
+
+# Generated code
+*.pb.go
+*.pb.gw.go
+
+# Dependencies
+vendor/
+go.sum
+
+# Test data and secrets
+*.vault
+*.queue
+.env
+.env.local
+.env.*.local
+
+# IDE and editor config
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Docker and build artifacts
+docker-compose.override.yml
+Dockerfile.dev
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.log
+
+# Large binaries and executables
+/tegata
+/tegata.exe
+/tegata-darwin
+
+# CI/CD artifacts
+.actrc


### PR DESCRIPTION
## Summary

This PR adds `.claudeignore` and `.copilotignore` files to exclude unnecessary files from AI assistant analysis, reducing token consumption.

## Related issues or PRs

N/A

## Changes made

- Added `.claudeignore` file with patterns for build artifacts, dependencies, generated code, test data, IDE config, and temporary files
- Added `.copilotignore` file with identical patterns for GitHub Copilot consistency
- Both files follow standard gitignore glob syntax and are version-controlled

## Technical implementation

- **Approach:** Use standard ignore file patterns to signal to AI tools which files can be safely excluded from context
- **Key components modified:** None (new files only)
- **Dependencies added/removed:** None
- **Design patterns used:** Standard .gitignore convention adapted for AI tools

## Testing performed

- [x] Verified both files exist in working directory
- [x] Confirmed patterns match common Go project artifacts (vendor/, *.pb.go, etc.)
- [x] Ensured sensitive files (.vault, .queue, .env) are excluded

## Security considerations

- [x] No sensitive data in files
- [x] Patterns prevent exposure of vault files, queues, and environment files
- [x] No new dependencies

## Code quality

- [x] Files follow standard gitignore formatting conventions
- [x] Patterns are well-organized with explanatory comments
- [x] No unused or redundant patterns

## Breaking changes

- [x] No breaking changes

## Additional context

These files help reduce token usage by Claude Code and GitHub Copilot by automatically excluding files that don't need to be analyzed. The patterns include build outputs, vendor dependencies, generated protobuf files, secret/test files (.vault, .queue, .env), IDE configurations, and temporary files.