### PR TITLE
Enable TLS for Tegata ledger setup and clarify insecure flag in docs

### DIFF
--- a/cmd/tegata/ledger.go
+++ b/cmd/tegata/ledger.go
@@ -78,20 +78,13 @@ func runLedgerSetup(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("audit.secret_key is required in tegata.toml")
 	}
 
-	// Create HMAC signer from secret key.
-	signer := audit.NewHMACSigner(cfg.Audit.SecretKey)
-	defer signer.Zero()
-
 	// Dial the ScalarDL Ledger.
 	fmt.Fprintf(os.Stderr, "Connecting to ScalarDL Ledger at %s (privileged: %s)...\n",
 		cfg.Audit.Server, cfg.Audit.PrivilegedServer)
-	var client *audit.LedgerClient
 	if cfg.Audit.Insecure {
 		fmt.Fprintln(os.Stderr, "WARNING: Insecure mode enabled — TLS disabled. Do not use in production.")
-		client, err = audit.NewLedgerClientInsecure(cfg.Audit.Server, cfg.Audit.PrivilegedServer, cfg.Audit.EntityID, cfg.Audit.KeyVersion, signer)
-	} else {
-		return fmt.Errorf("TLS mode not yet supported with HMAC auth — set insecure = true for local development")
 	}
+	client, err := audit.NewClientFromConfig(cfg.Audit)
 	if err != nil {
 		return fmt.Errorf("%w: connecting to ledger: %s", tegerrors.ErrNetworkFailed, err)
 	}

--- a/docs/scalardl-setup.md
+++ b/docs/scalardl-setup.md
@@ -198,6 +198,13 @@ If you are running your own ScalarDL instance rather than the bundled Docker sta
 
 Add the `[audit]` section to `tegata.toml` in your vault directory.
 
+The `insecure` field controls whether TLS is used for the ScalarDL connection. Set it based on where your ScalarDL instance is running.
+
+- **Local or self-hosted without TLS:** Set `insecure = true`. Traffic stays on your machine or local network, and no certificate is required on the server side.
+- **Remote or production server with TLS:** Omit `insecure` (or set `insecure = false`). Tegata uses the system CA pool by default. If your server uses a self-signed certificate, set `ca_cert_path` to the path of your CA certificate file.
+
+For a local ScalarDL instance:
+
 ```toml
 [audit]
 enabled           = true
@@ -207,11 +214,23 @@ entity_id         = "tegata-client"
 key_version       = 1
 secret_key        = "your-32-byte-hex-secret-key-here"
 insecure          = true
+auto_start        = false
 ```
 
-The `insecure = true` flag disables TLS, which is appropriate for local testing. Do not use this in production.
+For a remote ScalarDL instance with TLS:
 
-> **Known limitation:** TLS transport with HMAC authentication is not yet supported (tracked in issue #22). For production deployments, protect the connection at the network level using a VPN or SSH tunnel until TLS support is available.
+```toml
+[audit]
+enabled           = true
+server            = "scalardl.example.com:50051"
+privileged_server = "scalardl.example.com:50052"
+entity_id         = "tegata-client"
+key_version       = 1
+secret_key        = "your-32-byte-hex-secret-key-here"
+auto_start        = false
+```
+
+Set `auto_start = false` when managing ScalarDL yourself (locally or remotely). Tegata connects to the audit server automatically when needed — `auto_start` only controls whether Tegata starts a local Docker stack on vault unlock, which applies to the bundled one-click setup only.
 
 Then run `tegata ledger setup` to register your credentials.
 

--- a/docs/scalardl-setup.md
+++ b/docs/scalardl-setup.md
@@ -227,6 +227,7 @@ privileged_server = "scalardl.example.com:50052"
 entity_id         = "tegata-client"
 key_version       = 1
 secret_key        = "your-32-byte-hex-secret-key-here"
+# insecure        = false  # Default; TLS is enabled. You can omit this field for remote or production servers.
 auto_start        = false
 ```
 


### PR DESCRIPTION
## Summary

This PR fixes `tegata ledger setup` to use TLS when `insecure = false` (or omitted), and clarifies `insecure` and `auto_start` behavior in the manual setup documentation.

## Related issues or PRs

- Resolves #22

## Changes made

- Remove the hard error in `cmd/tegata/ledger.go` that blocked TLS connections with HMAC authentication in `tegata ledger setup`
- Replace the manual signer construction and `if/else` dial block with `audit.NewClientFromConfig`, which already handles both insecure and TLS paths correctly
- Remove the stale "Known limitation" note for #22 from `docs/scalardl-setup.md`
- Add separate TOML examples for local and remote ScalarDL instances with explanations of `insecure` and `auto_start`

## Technical implementation

- **Approach:** `audit.NewClientFromConfig` was already updated in the phase 10 refactor to support TLS via `buildTLSConfig`, but `ledger.go` was never updated to call it — it retained the old manual dial logic with a hard error for the TLS path
- **Key components modified:** `cmd/tegata/ledger.go`, `docs/scalardl-setup.md`
- **Dependencies added/removed:** None
- **Design patterns used:** `LedgerClient.Close` already zeros the signer internally via the `interface{ Zero() }` check, so the separate `signer` and `defer signer.Zero()` are redundant and removed

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [x] Unit tests pass (`go test ./cmd/tegata/... -count=1`)
- [ ] Integration tests pass (if applicable)
- [x] CLI commands tested manually with expected inputs
- [ ] ScalarDL integration tested (manual TLS path requires a live TLS-enabled ScalarDL instance)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data (`LedgerClient.Close` zeros the signer)
- [x] No new dependencies with known vulnerabilities
- [x] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Removed unused imports, variables, and functions (removed `signer` variable and `defer signer.Zero()`)
- [x] Documentation updated (scalardl-setup.md manual setup section)

## Breaking changes

- [x] No breaking changes

## Additional context

`auto_start` only triggers local Docker stack management via `MaybeAutoStart` — it is a no-op when `docker_compose_path` is not set, which is always the case for manual ScalarDL setups. The doc examples now show `auto_start = false` explicitly with an explanation so users are not left wondering.