### PR TITLE
Add Wayland clipboard support with graceful fallback

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -162,18 +162,19 @@ type waylandClipboard struct {
 	wlPastePath string
 }
 
-// newWaylandClipboard returns a waylandClipboard if wl-copy is available in
-// PATH. wl-paste is optional: ReadAll returns an error if it is absent.
+// newWaylandClipboard returns a waylandClipboard if both wl-copy and wl-paste
+// are available in PATH. Both tools are required: wl-paste is needed by the
+// auto-clear goroutine to compare clipboard content before clearing.
 func newWaylandClipboard() (*waylandClipboard, error) {
 	copyPath, err := exec.LookPath("wl-copy")
 	if err != nil {
 		return nil, fmt.Errorf("wl-copy not found: install wl-clipboard")
 	}
-	w := &waylandClipboard{wlCopyPath: copyPath}
-	if pastePath, err := exec.LookPath("wl-paste"); err == nil {
-		w.wlPastePath = pastePath
+	pastePath, err := exec.LookPath("wl-paste")
+	if err != nil {
+		return nil, fmt.Errorf("wl-paste not found: install wl-clipboard")
 	}
-	return w, nil
+	return &waylandClipboard{wlCopyPath: copyPath, wlPastePath: pastePath}, nil
 }
 
 func (w *waylandClipboard) WriteAll(text string) error {
@@ -186,9 +187,9 @@ func (w *waylandClipboard) WriteAll(text string) error {
 }
 
 func (w *waylandClipboard) ReadAll() (string, error) {
-	if w.wlPastePath == "" {
-		return "", fmt.Errorf("wl-paste not found: install wl-clipboard")
-	}
+	// wl-paste exits non-zero when the clipboard is empty. The auto-clear
+	// goroutine treats a ReadAll error as "content unknown" and skips clearing,
+	// which is safe — credentials are never cleared incorrectly.
 	out, err := exec.Command(w.wlPastePath, "--no-newline").Output()
 	if err != nil {
 		return "", fmt.Errorf("wl-paste: %w", err)
@@ -198,10 +199,11 @@ func (w *waylandClipboard) ReadAll() (string, error) {
 
 // Manager handles clipboard operations with automatic clearing.
 type Manager struct {
-	cb          ClipboardAccess
-	cancelClear context.CancelFunc
-	mu          sync.Mutex
-	tmpDir      string // set when WSL temp copies are used; cleaned up on Close
+	cb             ClipboardAccess
+	cancelClear    context.CancelFunc
+	mu             sync.Mutex
+	tmpDir         string // set when WSL temp copies are used; cleaned up on Close
+	waylandSession bool   // true when running in a Wayland session on Linux
 }
 
 // NewManager creates a new clipboard manager. On Linux the selection order is:
@@ -220,14 +222,23 @@ func NewManager() *Manager {
 					tmpDir: filepath.Dir(wsl.clipPath),
 				}
 			}
-			// Fall through to Wayland / X11 if WSL setup fails.
+			// Fall through to Wayland / X11 if WSL setup fails. On WSLg
+			// (WSL2 with GUI support), WAYLAND_DISPLAY may also be set, so
+			// the Wayland path below can succeed.
 		}
 		if isWayland() {
+			// Always record the session type so clipboardError can surface the
+			// right install hint even when wl-clipboard is absent and we fall
+			// through to the system clipboard.
+			m := &Manager{waylandSession: true}
 			if wl, err := newWaylandClipboard(); err == nil {
-				return &Manager{cb: wl}
+				m.cb = wl
+			} else {
+				// wl-clipboard absent; system clipboard will likely fail and
+				// clipboardError will surface an actionable install prompt.
+				m.cb = systemClipboard{}
 			}
-			// Fall through to system clipboard; the write will likely fail and
-			// clipboardError will surface an actionable message to the user.
+			return m
 		}
 	}
 	return &Manager{cb: systemClipboard{}}
@@ -253,7 +264,7 @@ func (m *Manager) CopyWithAutoClear(text string, timeout time.Duration) error {
 
 	if err := m.cb.WriteAll(text); err != nil {
 		m.mu.Unlock()
-		return clipboardError(err)
+		return m.clipboardError(err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -293,10 +304,12 @@ func (m *Manager) Close() {
 }
 
 // clipboardError wraps a clipboard error with an actionable message.
-func clipboardError(err error) error {
+// It uses the backend recorded at construction time rather than re-detecting
+// the session type, so the message always matches the backend in use.
+func (m *Manager) clipboardError(err error) error {
 	switch runtime.GOOS {
 	case "linux":
-		if isWayland() {
+		if m.waylandSession {
 			return &ClipboardError{
 				Err:     err,
 				Message: "Clipboard not available on Wayland. Install wl-clipboard (wl-copy/wl-paste).",

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -177,6 +177,7 @@ func newWaylandClipboard() (*waylandClipboard, error) {
 	return &waylandClipboard{wlCopyPath: copyPath, wlPastePath: pastePath}, nil
 }
 
+// WriteAll writes text to the Wayland clipboard via wl-copy.
 func (w *waylandClipboard) WriteAll(text string) error {
 	cmd := exec.Command(w.wlCopyPath)
 	cmd.Stdin = strings.NewReader(text)
@@ -234,8 +235,9 @@ func NewManager() *Manager {
 			if wl, err := newWaylandClipboard(); err == nil {
 				m.cb = wl
 			} else {
-				// wl-clipboard absent; system clipboard will likely fail and
-				// clipboardError will surface an actionable install prompt.
+				// wl-clipboard is absent. Assign system clipboard so the Manager
+				// is valid; the first operation will fail and clipboardError will
+				// surface the Wayland-specific install hint to the user.
 				m.cb = systemClipboard{}
 			}
 			return m

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -2,7 +2,8 @@
 // clearing after a timeout. It wraps github.com/atotto/clipboard with
 // auto-clear logic and cancellation support. On WSL2, clip.exe and
 // powershell.exe are copied to a temp directory (to gain execute bits that
-// DrvFs mounts strip) and used to reach the Windows clipboard.
+// DrvFs mounts strip) and used to reach the Windows clipboard. On Wayland,
+// wl-copy and wl-paste are used directly when available.
 package clipboard
 
 import (
@@ -144,6 +145,57 @@ func isWSL() bool {
 	return strings.Contains(strings.ToLower(string(data)), "microsoft")
 }
 
+// isWayland reports whether the process is running in a Wayland session.
+// It checks WAYLAND_DISPLAY first (set by the compositor) and falls back to
+// XDG_SESSION_TYPE for login managers that set one but not the other.
+func isWayland() bool {
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		return true
+	}
+	return strings.EqualFold(os.Getenv("XDG_SESSION_TYPE"), "wayland")
+}
+
+// waylandClipboard implements ClipboardAccess using wl-copy and wl-paste
+// from the wl-clipboard package, which natively supports Wayland.
+type waylandClipboard struct {
+	wlCopyPath  string
+	wlPastePath string
+}
+
+// newWaylandClipboard returns a waylandClipboard if wl-copy is available in
+// PATH. wl-paste is optional: ReadAll returns an error if it is absent.
+func newWaylandClipboard() (*waylandClipboard, error) {
+	copyPath, err := exec.LookPath("wl-copy")
+	if err != nil {
+		return nil, fmt.Errorf("wl-copy not found: install wl-clipboard")
+	}
+	w := &waylandClipboard{wlCopyPath: copyPath}
+	if pastePath, err := exec.LookPath("wl-paste"); err == nil {
+		w.wlPastePath = pastePath
+	}
+	return w, nil
+}
+
+func (w *waylandClipboard) WriteAll(text string) error {
+	cmd := exec.Command(w.wlCopyPath)
+	cmd.Stdin = strings.NewReader(text)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("wl-copy: %w", err)
+	}
+	return nil
+}
+
+func (w *waylandClipboard) ReadAll() (string, error) {
+	if w.wlPastePath == "" {
+		return "", fmt.Errorf("wl-paste not found: install wl-clipboard")
+	}
+	out, err := exec.Command(w.wlPastePath, "--no-newline").Output()
+	if err != nil {
+		return "", fmt.Errorf("wl-paste: %w", err)
+	}
+	return string(out), nil
+}
+
 // Manager handles clipboard operations with automatic clearing.
 type Manager struct {
 	cb          ClipboardAccess
@@ -152,19 +204,31 @@ type Manager struct {
 	tmpDir      string // set when WSL temp copies are used; cleaned up on Close
 }
 
-// NewManager creates a new clipboard manager. On WSL2 it copies Windows
-// clipboard binaries to a temp directory (to work around DrvFs execute-bit
-// restrictions) and uses them directly. Elsewhere it uses the system clipboard
-// via atotto/clipboard.
+// NewManager creates a new clipboard manager. On Linux the selection order is:
+//  1. WSL2 — uses Windows clipboard binaries copied to a temp directory to
+//     work around DrvFs execute-bit restrictions.
+//  2. Wayland — uses wl-copy/wl-paste from wl-clipboard when detected.
+//  3. X11 / other — falls through to atotto/clipboard (xclip / xsel).
+//
+// On macOS and Windows the system clipboard is used directly.
 func NewManager() *Manager {
-	if runtime.GOOS == "linux" && isWSL() {
-		if wsl, err := newWSLClipboard(); err == nil {
-			return &Manager{
-				cb:     wsl,
-				tmpDir: filepath.Dir(wsl.clipPath),
+	if runtime.GOOS == "linux" {
+		if isWSL() {
+			if wsl, err := newWSLClipboard(); err == nil {
+				return &Manager{
+					cb:     wsl,
+					tmpDir: filepath.Dir(wsl.clipPath),
+				}
 			}
+			// Fall through to Wayland / X11 if WSL setup fails.
 		}
-		// Fall through to system clipboard if WSL setup fails.
+		if isWayland() {
+			if wl, err := newWaylandClipboard(); err == nil {
+				return &Manager{cb: wl}
+			}
+			// Fall through to system clipboard; the write will likely fail and
+			// clipboardError will surface an actionable message to the user.
+		}
 	}
 	return &Manager{cb: systemClipboard{}}
 }
@@ -232,9 +296,15 @@ func (m *Manager) Close() {
 func clipboardError(err error) error {
 	switch runtime.GOOS {
 	case "linux":
+		if isWayland() {
+			return &ClipboardError{
+				Err:     err,
+				Message: "Clipboard not available on Wayland. Install wl-clipboard (wl-copy/wl-paste).",
+			}
+		}
 		return &ClipboardError{
 			Err:     err,
-			Message: "Clipboard not available. Install xclip, xsel, or wl-clipboard.",
+			Message: "Clipboard not available. Install xclip or xsel.",
 		}
 	default:
 		return &ClipboardError{

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,6 +1,7 @@
 package clipboard
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -143,5 +144,58 @@ func TestCloseStopsAutoClear(t *testing.T) {
 	got := mock.getContent()
 	if got != "secret" {
 		t.Errorf("clipboard should not be cleared after Close, got %q", got)
+	}
+}
+
+// errClipboard is a mock ClipboardAccess that always returns an error on write.
+type errClipboard struct{ err error }
+
+func (e *errClipboard) WriteAll(_ string) error  { return e.err }
+func (e *errClipboard) ReadAll() (string, error) { return "", e.err }
+
+func TestCopyWithAutoClearReturnsClipboardError(t *testing.T) {
+	underlying := errors.New("display not found")
+	mgr := NewManagerWith(&errClipboard{err: underlying})
+	defer mgr.Close()
+
+	err := mgr.CopyWithAutoClear("secret", time.Second)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var ce *ClipboardError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *ClipboardError, got %T: %v", err, err)
+	}
+	if ce.Unwrap() == nil {
+		t.Error("ClipboardError should wrap the underlying error")
+	}
+}
+
+func TestIsWaylandDetection(t *testing.T) {
+	tests := []struct {
+		name           string
+		waylandDisplay string
+		xdgSessionType string
+		want           bool
+	}{
+		{"no wayland env", "", "", false},
+		{"WAYLAND_DISPLAY set", "wayland-0", "", true},
+		{"XDG_SESSION_TYPE wayland", "", "wayland", true},
+		{"XDG_SESSION_TYPE WAYLAND uppercase", "", "WAYLAND", true},
+		{"XDG_SESSION_TYPE x11", "", "x11", false},
+		{"both set", "wayland-0", "wayland", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("WAYLAND_DISPLAY", tc.waylandDisplay)
+			t.Setenv("XDG_SESSION_TYPE", tc.xdgSessionType)
+
+			got := isWayland()
+			if got != tc.want {
+				t.Errorf("isWayland() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -184,6 +186,9 @@ func TestNewWaylandClipboardFailsWithoutWlCopy(t *testing.T) {
 }
 
 func TestNewWaylandClipboardFailsWithoutWlPaste(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Unix executable stubs only work on Linux")
+	}
 	// Create a temp dir that contains wl-copy but not wl-paste so that only
 	// the wl-paste look-up fails.
 	tmpDir := t.TempDir()
@@ -224,5 +229,33 @@ func TestIsWaylandDetection(t *testing.T) {
 				t.Errorf("isWayland() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestClipboardErrorMessageWaylandSession(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("waylandSession error path is Linux-only")
+	}
+	underlying := errors.New("exit status 1")
+	mgr := &Manager{
+		waylandSession: true,
+		cb:             &errClipboard{err: underlying},
+	}
+	defer mgr.Close()
+
+	err := mgr.CopyWithAutoClear("secret", time.Second)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var ce *ClipboardError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *ClipboardError, got %T: %v", err, err)
+	}
+	if !strings.Contains(ce.Message, "wl-clipboard") {
+		t.Errorf("expected Wayland install hint in message, got %q", ce.Message)
+	}
+	if ce.Unwrap() != underlying {
+		t.Errorf("expected underlying error %v, got %v", underlying, ce.Unwrap())
 	}
 }

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -2,6 +2,8 @@ package clipboard
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -169,6 +171,31 @@ func TestCopyWithAutoClearReturnsClipboardError(t *testing.T) {
 	}
 	if ce.Unwrap() == nil {
 		t.Error("ClipboardError should wrap the underlying error")
+	}
+}
+
+func TestNewWaylandClipboardFailsWithoutWlCopy(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	_, err := newWaylandClipboard()
+	if err == nil {
+		t.Error("expected error when wl-copy is absent, got nil")
+	}
+}
+
+func TestNewWaylandClipboardFailsWithoutWlPaste(t *testing.T) {
+	// Create a temp dir that contains wl-copy but not wl-paste so that only
+	// the wl-paste look-up fails.
+	tmpDir := t.TempDir()
+	fakeCopy := filepath.Join(tmpDir, "wl-copy")
+	if err := os.WriteFile(fakeCopy, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tmpDir)
+
+	_, err := newWaylandClipboard()
+	if err == nil {
+		t.Error("expected error when wl-paste is absent, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR adds native Wayland clipboard support to prevent silent failures or crashes when users copy credentials on Wayland-based Linux desktops (GNOME 41+, KDE Plasma 5.24+).

## Related issues or PRs

- Resolves #41

## Changes made

- Added `isWayland()` detection using `WAYLAND_DISPLAY` and `XDG_SESSION_TYPE` env vars
- Added `waylandClipboard` type that uses `wl-copy`/`wl-paste` from `wl-clipboard` directly
- Updated `NewManager()` to try WSL2 → Wayland → X11 in order on Linux
- Updated `clipboardError()` to return a Wayland-specific install message when on Wayland
- Tightened X11 error message to reference only `xclip`/`xsel`
- Added `TestCopyWithAutoClearReturnsClipboardError` and `TestIsWaylandDetection` tests

## Technical implementation

- **Approach:** Mirror the existing `wslClipboard` pattern — detect environment, exec the native tool via stdin/stdout, fall through gracefully if unavailable
- **Key components modified:** `internal/clipboard/clipboard.go`, `internal/clipboard/clipboard_test.go`
- **Dependencies added/removed:** None — uses `wl-copy`/`wl-paste` as external system tools (same pattern as `xclip`/`xsel`)
- **Design patterns used:** Strategy pattern via `ClipboardAccess` interface; same fallthrough-on-failure approach as WSL2 path

## Testing performed

- [ ] Builds successfully on macOS (arm64) (if applicable) — not applicable
- [ ] Builds successfully on Linux (amd64) — not tested; no Linux machine available
- [ ] Builds successfully on Windows (if applicable) — not applicable
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] CLI commands tested manually with expected inputs — Wayland path untested; no Wayland machine available
- [x] Edge cases and error handling tested (missing wl-copy, write failures, env var combinations)
- [ ] Cryptographic operations verified (if applicable) — N/A
- [ ] ScalarDL integration tested (if applicable) — N/A
- [ ] Cross-platform compatibility verified (if applicable) — macOS verified; Wayland path requires manual verification on a Wayland system

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [x] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [x] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes

## Additional context

The `wl-paste --no-newline` flag is intentional — without it, `wl-paste` appends a trailing newline, which would break the auto-clear comparison (`current == text`) and leave credentials in the clipboard indefinitely after the timeout.

Reviewers with a Wayland machine should test: (1) with `wl-clipboard` installed — confirm copy and auto-clear work, and (2) without `wl-clipboard` installed — confirm the error message "Clipboard not available on Wayland. Install wl-clipboard (wl-copy/wl-paste)." appears.