### PR TITLE
Idle timer should start after login, not on app open

### DIFF
--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -55,7 +55,7 @@ function App() {
     if (vault.isUnlocked) {
       creds.refresh()
     }
-  }, [vault.isUnlocked]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [vault.isUnlocked, creds.refresh])
 
   const handleRemove = useCallback(
     async (id: string) => {

--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -46,7 +46,10 @@ function App() {
     vault.lock()
   }, [vault])
 
-  useIdleTimer(idleTimeoutMs, handleLock)
+  // Only run the idle timer while the vault is unlocked. Passing 0 when the
+  // user is on the setup or unlock screen disables the timer so pre-login
+  // inactivity cannot trigger a lock transition (issue #34).
+  useIdleTimer(vault.view === "main" ? idleTimeoutMs : 0, handleLock)
 
   useEffect(() => {
     if (vault.view === "main") {

--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -35,12 +35,12 @@ function App() {
   }, [settingsOpen])
 
   useEffect(() => {
-    if (vault.view === "main") {
+    if (vault.isUnlocked) {
       WailsApp.IsAuditEnabled()
         .then(setAuditEnabled)
         .catch(() => setAuditEnabled(false))
     }
-  }, [vault.view])
+  }, [vault.isUnlocked])
 
   const handleLock = useCallback(() => {
     vault.lock()
@@ -49,13 +49,13 @@ function App() {
   // Only run the idle timer while the vault is unlocked. Passing 0 when the
   // user is on the setup or unlock screen disables the timer so pre-login
   // inactivity cannot trigger a lock transition (issue #34).
-  useIdleTimer(vault.view === "main" ? idleTimeoutMs : 0, handleLock)
+  useIdleTimer(vault.isUnlocked ? idleTimeoutMs : 0, handleLock)
 
   useEffect(() => {
-    if (vault.view === "main") {
+    if (vault.isUnlocked) {
       creds.refresh()
     }
-  }, [vault.view]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [vault.isUnlocked]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleRemove = useCallback(
     async (id: string) => {

--- a/cmd/tegata-gui/frontend/src/hooks/useIdleTimer.test.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useIdleTimer.test.ts
@@ -79,4 +79,40 @@ describe("useIdleTimer", () => {
 
     expect(onIdle).not.toHaveBeenCalled()
   })
+
+  it("resets activity baseline when re-enabled after being disabled (login transition)", () => {
+    // Simulate the pattern used in App.tsx: pass 0 while pre-login, then the
+    // real timeout after the user authenticates. The timer must not fire
+    // immediately after enabling — the activity baseline should reset so that
+    // time spent on pre-login screens does not count toward the idle window.
+    const onIdle = vi.fn()
+    let timeout = 0
+    const { rerender } = renderHook(() => useIdleTimer(timeout, onIdle))
+
+    // Advance 9 minutes while the timer is disabled (timeout = 0).
+    act(() => {
+      vi.advanceTimersByTime(9 * 60 * 1000)
+    })
+    expect(onIdle).not.toHaveBeenCalled()
+
+    // Simulate login: enable the timer with a 5-minute window.
+    timeout = 5 * 60 * 1000
+    rerender()
+
+    // Advance 4 minutes — the 9 pre-login minutes must not count; the user
+    // should still have 1 minute of idle budget remaining.
+    act(() => {
+      vi.advanceTimersByTime(4 * 60 * 1000)
+    })
+    expect(onIdle).not.toHaveBeenCalled()
+
+    // Advance 1 minute and 5 seconds — past the 5-minute window from login.
+    // The hook polls every 5 s, so the callback fires at least once in this
+    // window. (It may fire multiple times because lastActivity is not reset on
+    // each poll; the caller is responsible for disabling the timer on lock.)
+    act(() => {
+      vi.advanceTimersByTime(65 * 1000)
+    })
+    expect(onIdle).toHaveBeenCalled()
+  })
 })

--- a/cmd/tegata-gui/frontend/src/hooks/useIdleTimer.test.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useIdleTimer.test.ts
@@ -108,8 +108,8 @@ describe("useIdleTimer", () => {
 
     // Advance 1 minute and 5 seconds — past the 5-minute window from login.
     // The hook polls every 5 s, so the callback fires at least once in this
-    // window. (It may fire multiple times because lastActivity is not reset on
-    // each poll; the caller is responsible for disabling the timer on lock.)
+    // window. The baseline is reset before onIdle fires, so the callback fires
+    // at most once per idle window even if the lock transition is slow.
     act(() => {
       vi.advanceTimersByTime(65 * 1000)
     })

--- a/cmd/tegata-gui/frontend/src/hooks/useIdleTimer.test.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useIdleTimer.test.ts
@@ -113,6 +113,6 @@ describe("useIdleTimer", () => {
     act(() => {
       vi.advanceTimersByTime(65 * 1000)
     })
-    expect(onIdle).toHaveBeenCalled()
+    expect(onIdle).toHaveBeenCalledTimes(1)
   })
 })

--- a/cmd/tegata-gui/frontend/src/hooks/useIdleTimer.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useIdleTimer.ts
@@ -24,6 +24,9 @@ export function useIdleTimer(timeoutMs: number, onIdle: () => void) {
 
     const interval = setInterval(() => {
       if (Date.now() - lastActivity.current >= timeoutMs) {
+        // Reset the baseline so the timer cannot re-fire before the caller
+        // disables it (e.g. while an async lock transition is in flight).
+        lastActivity.current = Date.now()
         onIdle()
       }
     }, 5000)

--- a/cmd/tegata-gui/frontend/src/hooks/useVault.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useVault.ts
@@ -87,6 +87,7 @@ export function useVault() {
   return {
     view,
     setView,
+    isUnlocked: view === "main",
     vaultPath,
     setVaultPath,
     vaultLocations,


### PR DESCRIPTION
## Summary

This PR fixes the idle timer running during setup/unlock screens instead of after authentication. Users cannot complete vault setup or vault switching because the app locks after 5 minutes of pre-login inactivity.

## Related issues or PRs

Resolves #34

## Changes made

- Only pass idle timeout to useIdleTimer when vault is unlocked (vault.isUnlocked)
- Pass 0 to useIdleTimer during setup/unlock screens to disable the timer
- Added test case validating pre-login inactivity does not count toward idle window

## Technical implementation

- **Approach:** Conditional idle timeout parameter based on authentication state (vault.isUnlocked)
- **Key components modified:** cmd/tegata-gui/frontend/src/App.tsx, cmd/tegata-gui/frontend/src/hooks/useIdleTimer.ts, cmd/tegata-gui/frontend/src/hooks/useIdleTimer.test.ts
- **Dependencies added/removed:** None
- **Design patterns used:** Conditional React hook parameter; reuses existing hook no-op behavior for timeoutMs <= 0

## Testing performed

- [ ] Builds successfully on Linux (amd64)
- [x] Builds successfully on macOS (if applicable)
- [x] Builds successfully on Windows (if applicable)
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] CLI commands tested manually with expected inputs
- [ ] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable)
- [ ] ScalarDL integration tested (if applicable)
- [ ] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [x] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (TypeScript style guidelines)
- [x] Added appropriate comments for complex logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes

## Additional context

TUI implementation in cmd/tegata/ already correctly defers idle timer start until after vault unlock, so only the GUI needed this fix.