### PR TITLE
Fix GUI vault opening flow bugs

### DIFF
--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -136,7 +136,8 @@ function App() {
         onUnlock={vault.unlock}
         onSelectVault={vault.setVaultPath}
         onBack={() => {
-          setSetupStep(1)
+          vault.clearError()
+          setSetupStep(6)
           vault.setView("setup")
         }}
       />

--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -137,7 +137,7 @@ function App() {
         onSelectVault={vault.setVaultPath}
         onBack={() => {
           vault.clearError()
-          setSetupStep(6)
+          setSetupStep(6) // step 6 = "Open existing vault" screen
           vault.setView("setup")
         }}
       />

--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -15,6 +15,9 @@ import { useIdleTimer } from "@/hooks/useIdleTimer"
 import { App as WailsApp } from "@/lib/wails"
 import type { UpdateInfo } from "@/lib/types"
 
+const SETUP_STEP_WELCOME = 1 as const
+const SETUP_STEP_OPEN_EXISTING = 6 as const
+
 function App() {
   const vault = useVault()
   const creds = useCredentials()
@@ -23,7 +26,7 @@ function App() {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [auditOpen, setAuditOpen] = useState(false)
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null)
-  const [setupStep, setSetupStep] = useState<1 | 2 | 3 | 4 | 5 | 6>(1)
+  const [setupStep, setSetupStep] = useState<1 | 2 | 3 | 4 | 5 | 6>(SETUP_STEP_WELCOME)
   const [isSwitching, setIsSwitching] = useState(false)
   const [idleTimeoutMs, setIdleTimeoutMs] = useState(5 * 60 * 1000)
   const [auditEnabled, setAuditEnabled] = useState(false)
@@ -113,7 +116,7 @@ function App() {
           if (isSwitching) {
             try { await WailsApp.LockVault() } catch { /* non-critical */ }
           }
-          setSetupStep(6)
+          setSetupStep(SETUP_STEP_OPEN_EXISTING)
           setIsSwitching(false)
           vault.setVaultPath(path)
           vault.setView("unlock")
@@ -137,7 +140,7 @@ function App() {
         onSelectVault={vault.setVaultPath}
         onBack={() => {
           vault.clearError()
-          setSetupStep(6) // step 6 = "Open existing vault" screen
+          setSetupStep(SETUP_STEP_OPEN_EXISTING)
           vault.setView("setup")
         }}
       />
@@ -150,7 +153,7 @@ function App() {
         onSettingsClick={() => setSettingsOpen(true)}
         onAuditClick={auditEnabled ? () => setAuditOpen(true) : undefined}
         onSwitchVault={() => {
-          setSetupStep(1)
+          setSetupStep(SETUP_STEP_WELCOME)
           setIsSwitching(true)
           vault.setView("setup")
         }}

--- a/cmd/tegata-gui/frontend/src/components/vault/UnlockView.test.tsx
+++ b/cmd/tegata-gui/frontend/src/components/vault/UnlockView.test.tsx
@@ -35,8 +35,35 @@ describe("UnlockView", () => {
   })
 
   it("shows error message when error prop is set", () => {
-    render(<UnlockView {...defaultProps} error="Wrong passphrase" />)
-    expect(screen.getByText("Wrong passphrase")).toBeInTheDocument()
+    render(<UnlockView {...defaultProps} error="Incorrect passphrase. Please try again." />)
+    expect(screen.getByText("Incorrect passphrase. Please try again.")).toBeInTheDocument()
+  })
+
+  it("clears error message when user starts typing a new passphrase", async () => {
+    const user = userEvent.setup()
+    render(<UnlockView {...defaultProps} error="Incorrect passphrase. Please try again." />)
+
+    expect(screen.getByText("Incorrect passphrase. Please try again.")).toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText("Passphrase"), "a")
+
+    expect(screen.queryByText("Incorrect passphrase. Please try again.")).not.toBeInTheDocument()
+  })
+
+  it("re-shows error when a new error arrives after dismissal", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <UnlockView {...defaultProps} error="Incorrect passphrase. Please try again." />,
+    )
+
+    await user.type(screen.getByPlaceholderText("Passphrase"), "a")
+    expect(screen.queryByText("Incorrect passphrase. Please try again.")).not.toBeInTheDocument()
+
+    // Simulate a second failed attempt: prop flips null → message to trigger the effect.
+    rerender(<UnlockView {...defaultProps} error={null} />)
+    rerender(<UnlockView {...defaultProps} error="Incorrect passphrase. Please try again." />)
+
+    expect(screen.getByText("Incorrect passphrase. Please try again.")).toBeInTheDocument()
   })
 
   it("Unlock button is disabled when passphrase is empty", () => {

--- a/cmd/tegata-gui/frontend/src/components/vault/UnlockView.test.tsx
+++ b/cmd/tegata-gui/frontend/src/components/vault/UnlockView.test.tsx
@@ -59,7 +59,9 @@ describe("UnlockView", () => {
     await user.type(screen.getByPlaceholderText("Passphrase"), "a")
     expect(screen.queryByText("Incorrect passphrase. Please try again.")).not.toBeInTheDocument()
 
-    // Simulate a second failed attempt: prop flips null → message to trigger the effect.
+    // Mirrors real useVault behavior: error cycles through null before each
+    // attempt (setError(null) then setError(message)), so the useEffect fires
+    // even when consecutive failures produce the same string.
     rerender(<UnlockView {...defaultProps} error={null} />)
     rerender(<UnlockView {...defaultProps} error="Incorrect passphrase. Please try again." />)
 

--- a/cmd/tegata-gui/frontend/src/components/vault/UnlockView.tsx
+++ b/cmd/tegata-gui/frontend/src/components/vault/UnlockView.tsx
@@ -27,6 +27,7 @@ export function UnlockView({
 }: UnlockViewProps) {
   const [passphrase, setPassphrase] = useState("")
   const [auditStatus, setAuditStatus] = useState("")
+  const [errorDismissed, setErrorDismissed] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -37,6 +38,11 @@ export function UnlockView({
   useEffect(() => {
     if (!loading) setAuditStatus("")
   }, [loading])
+
+  // Reset dismissal whenever a new error arrives so it becomes visible again.
+  useEffect(() => {
+    if (error) setErrorDismissed(false)
+  }, [error])
 
   useEffect(() => {
     // The Wails WebView may not accept focus until its layout is fully
@@ -111,12 +117,12 @@ export function UnlockView({
               type="password"
               placeholder="Passphrase"
               value={passphrase}
-              onChange={(e) => setPassphrase(e.target.value)}
+              onChange={(e) => { setPassphrase(e.target.value); setErrorDismissed(true) }}
               maxLength={256}
               autoFocus
               disabled={loading}
             />
-            {error && (
+            {error && !errorDismissed && (
               <p className="text-sm text-destructive">{error}</p>
             )}
           </div>

--- a/cmd/tegata-gui/frontend/src/components/vault/UnlockView.tsx
+++ b/cmd/tegata-gui/frontend/src/components/vault/UnlockView.tsx
@@ -27,7 +27,7 @@ export function UnlockView({
 }: UnlockViewProps) {
   const [passphrase, setPassphrase] = useState("")
   const [auditStatus, setAuditStatus] = useState("")
-  const [errorDismissed, setErrorDismissed] = useState(false)
+  const [showError, setShowError] = useState(true)
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -39,9 +39,9 @@ export function UnlockView({
     if (!loading) setAuditStatus("")
   }, [loading])
 
-  // Reset dismissal whenever a new error arrives so it becomes visible again.
+  // Show the error whenever a new one arrives (re-enables after user dismissed).
   useEffect(() => {
-    if (error) setErrorDismissed(false)
+    if (error) setShowError(true)
   }, [error])
 
   useEffect(() => {
@@ -62,7 +62,7 @@ export function UnlockView({
 
   function handlePassphraseChange(e: ChangeEvent<HTMLInputElement>) {
     setPassphrase(e.target.value)
-    setErrorDismissed(true)
+    setShowError(false)
   }
 
   function handleSubmit(e: FormEvent) {
@@ -127,7 +127,7 @@ export function UnlockView({
               autoFocus
               disabled={loading}
             />
-            {error && !errorDismissed && (
+            {error && showError && (
               <p className="text-sm text-destructive">{error}</p>
             )}
           </div>

--- a/cmd/tegata-gui/frontend/src/components/vault/UnlockView.tsx
+++ b/cmd/tegata-gui/frontend/src/components/vault/UnlockView.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useEffect, useRef, useState } from "react"
+import { type ChangeEvent, type FormEvent, useEffect, useRef, useState } from "react"
 import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -60,6 +60,11 @@ export function UnlockView({
     return () => clearInterval(interval)
   }, [])
 
+  function handlePassphraseChange(e: ChangeEvent<HTMLInputElement>) {
+    setPassphrase(e.target.value)
+    setErrorDismissed(true)
+  }
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
     if (!passphrase || loading) return
@@ -117,7 +122,7 @@ export function UnlockView({
               type="password"
               placeholder="Passphrase"
               value={passphrase}
-              onChange={(e) => { setPassphrase(e.target.value); setErrorDismissed(true) }}
+              onChange={handlePassphraseChange}
               maxLength={256}
               autoFocus
               disabled={loading}

--- a/cmd/tegata-gui/frontend/src/hooks/useVault.test.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useVault.test.ts
@@ -106,7 +106,6 @@ describe("useVault", () => {
     expect(result.current.error).toBe("Incorrect passphrase. Please try again.")
   })
 
-
   it("lock calls App.LockVault and transitions to 'unlock'", async () => {
     vi.mocked(App.ScanForVaults).mockResolvedValue([
       { path: "/usb/vault.tegata", driveName: "USB" },

--- a/cmd/tegata-gui/frontend/src/hooks/useVault.test.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useVault.test.ts
@@ -69,7 +69,7 @@ describe("useVault", () => {
     })
 
     expect(result.current.view).toBe("unlock")
-    expect(result.current.error).toBe("wrong passphrase")
+    expect(result.current.error).toBe("Incorrect passphrase. Please try again.")
   })
 
   it("lock calls App.LockVault and transitions to 'unlock'", async () => {

--- a/cmd/tegata-gui/frontend/src/hooks/useVault.test.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useVault.test.ts
@@ -72,6 +72,23 @@ describe("useVault", () => {
     expect(result.current.error).toBe("Incorrect passphrase. Please try again.")
   })
 
+  it("unlock non-passphrase failure shows generic error", async () => {
+    vi.mocked(App.ScanForVaults).mockResolvedValue([
+      { path: "/usb/vault.tegata", driveName: "USB" },
+    ])
+    vi.mocked(App.UnlockVault).mockRejectedValue(new Error("permission denied"))
+
+    const { result } = renderHook(() => useVault())
+    await waitFor(() => expect(result.current.view).toBe("unlock"))
+
+    await act(async () => {
+      await result.current.unlock("test-passphrase-dummy")
+    })
+
+    expect(result.current.view).toBe("unlock")
+    expect(result.current.error).toBe("Failed to open vault. Please try again.")
+  })
+
   it("lock calls App.LockVault and transitions to 'unlock'", async () => {
     vi.mocked(App.ScanForVaults).mockResolvedValue([
       { path: "/usb/vault.tegata", driveName: "USB" },

--- a/cmd/tegata-gui/frontend/src/hooks/useVault.test.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useVault.test.ts
@@ -72,7 +72,7 @@ describe("useVault", () => {
     expect(result.current.error).toBe("Incorrect passphrase. Please try again.")
   })
 
-  it("unlock non-passphrase failure shows generic error", async () => {
+  it("unlock system-level failure shows generic vault-access error", async () => {
     vi.mocked(App.ScanForVaults).mockResolvedValue([
       { path: "/usb/vault.tegata", driveName: "USB" },
     ])
@@ -88,6 +88,24 @@ describe("useVault", () => {
     expect(result.current.view).toBe("unlock")
     expect(result.current.error).toBe("Failed to open vault. Please try again.")
   })
+
+  it("unlock unknown failure defaults to passphrase error", async () => {
+    vi.mocked(App.ScanForVaults).mockResolvedValue([
+      { path: "/usb/vault.tegata", driveName: "USB" },
+    ])
+    vi.mocked(App.UnlockVault).mockRejectedValue(new Error("some unexpected backend error"))
+
+    const { result } = renderHook(() => useVault())
+    await waitFor(() => expect(result.current.view).toBe("unlock"))
+
+    await act(async () => {
+      await result.current.unlock("test-passphrase-dummy")
+    })
+
+    expect(result.current.view).toBe("unlock")
+    expect(result.current.error).toBe("Incorrect passphrase. Please try again.")
+  })
+
 
   it("lock calls App.LockVault and transitions to 'unlock'", async () => {
     vi.mocked(App.ScanForVaults).mockResolvedValue([

--- a/cmd/tegata-gui/frontend/src/hooks/useVault.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useVault.ts
@@ -45,7 +45,8 @@ export function useVault() {
       try {
         await App.UnlockVault(vaultPath, passphrase)
         setView("main")
-      } catch {
+      } catch (err) {
+        console.error("UnlockVault failed:", err)
         setError("Incorrect passphrase. Please try again.")
       } finally {
         setLoading(false)

--- a/cmd/tegata-gui/frontend/src/hooks/useVault.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useVault.ts
@@ -45,8 +45,8 @@ export function useVault() {
       try {
         await App.UnlockVault(vaultPath, passphrase)
         setView("main")
-      } catch (err) {
-        setError(formatError(err, "Failed to unlock vault"))
+      } catch {
+        setError("Incorrect passphrase. Please try again.")
       } finally {
         setLoading(false)
       }
@@ -84,6 +84,8 @@ export function useVault() {
     [],
   )
 
+  const clearError = useCallback(() => setError(null), [])
+
   return {
     view,
     setView,
@@ -92,6 +94,7 @@ export function useVault() {
     setVaultPath,
     vaultLocations,
     error,
+    clearError,
     loading,
     unlock,
     lock,

--- a/cmd/tegata-gui/frontend/src/hooks/useVault.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useVault.ts
@@ -41,20 +41,29 @@ export function useVault() {
     async (passphrase: string) => {
       if (!vaultPath) return
       setLoading(true)
+      // Must remain here: cycling error through null before each attempt ensures
+      // UnlockView's showError state re-triggers even when consecutive failures
+      // produce the same error string.
       setError(null)
       try {
         await App.UnlockVault(vaultPath, passphrase)
         setView("main")
       } catch (err) {
         const raw = formatError(err, "")
-        // Backend auth failures typically contain these patterns (e.g. Go's
-        // "cipher: message authentication failed"). Anything else is treated
-        // as a vault-access failure, not a wrong-passphrase error.
-        const isPassphraseError = !raw || /passphrase|cipher|decrypt|authenticat/i.test(raw)
+        // Default to the passphrase error for all failures — most unlock errors
+        // are wrong passphrases. Only show the generic vault-access message when
+        // we can positively identify a system-level cause (file permissions,
+        // missing file, etc.) where a wrong passphrase clearly isn't the issue.
+        // TODO: Replace this heuristic with structured error codes from the Go
+        // backend so the distinction is reliable and not coupled to error message
+        // wording (#63).
+        const isSystemError = raw
+          ? /permission denied|no such file|access denied|read-only file/i.test(raw)
+          : false
         setError(
-          isPassphraseError
-            ? "Incorrect passphrase. Please try again."
-            : "Failed to open vault. Please try again.",
+          isSystemError
+            ? "Failed to open vault. Please try again."
+            : "Incorrect passphrase. Please try again.",
         )
       } finally {
         setLoading(false)

--- a/cmd/tegata-gui/frontend/src/hooks/useVault.ts
+++ b/cmd/tegata-gui/frontend/src/hooks/useVault.ts
@@ -46,8 +46,16 @@ export function useVault() {
         await App.UnlockVault(vaultPath, passphrase)
         setView("main")
       } catch (err) {
-        console.error("UnlockVault failed:", err)
-        setError("Incorrect passphrase. Please try again.")
+        const raw = formatError(err, "")
+        // Backend auth failures typically contain these patterns (e.g. Go's
+        // "cipher: message authentication failed"). Anything else is treated
+        // as a vault-access failure, not a wrong-passphrase error.
+        const isPassphraseError = !raw || /passphrase|cipher|decrypt|authenticat/i.test(raw)
+        setError(
+          isPassphraseError
+            ? "Incorrect passphrase. Please try again."
+            : "Failed to open vault. Please try again.",
+        )
       } finally {
         setLoading(false)
       }


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the GUI vault opening flow: incorrect back-button navigation and persistent, technical-language error messages on the unlock screen.

## Related issues or PRs

- Resolves #60

## Changes made

- Fixed back button in `UnlockView` to return to the "Open existing vault" screen (step 6) instead of the Welcome screen (step 1)
- Replaced raw backend error messages on the unlock screen with the user-friendly message "Incorrect passphrase. Please try again."
- Added auto-clear behavior so the error message disappears as soon as the user starts typing a new passphrase
- Exposed `clearError` from `useVault` so navigation actions can reset error state
- Updated and added unit tests to cover the new error dismissal behavior

## Technical implementation

- **Approach:** Minimal, targeted fixes to the affected components with no structural changes to the wizard state machine.
- **Key components modified:** `App.tsx`, `useVault.ts`, `UnlockView.tsx`, `UnlockView.test.tsx`, `useVault.test.ts`
- **Dependencies added/removed:** None
- **Design patterns used:** Local `errorDismissed` boolean state in `UnlockView` resets via `useEffect` when a new error prop arrives and is cleared on any passphrase `onChange`, keeping error lifecycle contained to the component without requiring a callback prop.

## Testing performed

- [ ] Builds successfully on Linux (amd64)
- [x] Builds successfully on macOS (if applicable)
- [x] Builds successfully on Windows (if applicable)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] CLI commands tested manually with expected inputs
- [x] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable)
- [ ] ScalarDL integration tested (if applicable)
- [ ] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [ ] Cryptographic operations use secure, well-tested libraries
- [ ] Memory is zeroed after handling sensitive data
- [ ] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [ ] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [ ] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes

## Additional context

Both fixes were manually verified in the Wails dev environment (`make gui-dev`) on macOS:

- Back button from the unlock screen correctly returns to the "Open existing vault" screen.
- Wrong-passphrase errors display as "Incorrect passphrase. Please try again." and clear on the first keystroke.