### PR TITLE
Fix audit validation to detect real tampering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
   integration-tests:
     name: Integration tests (Docker)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: [build-and-test]
     steps:
       - name: Checkout code
@@ -90,4 +90,4 @@ jobs:
         run: docker info
 
       - name: Run Docker integration tests
-        run: go test -tags integration ./internal/audit/... -v -timeout 10m
+        run: go test -tags integration ./internal/audit/... -v -timeout 20m

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,559 @@
+# Roadmap: Tegata
+
+## Overview
+
+Tegata delivers a portable encrypted authenticator in six phases, building bottom-up from cryptographic primitives to a full desktop GUI. Phase 1 establishes the security foundation that every subsequent component depends on. Phase 2 delivers a complete standalone authenticator (vault, TOTP, HOTP, static passwords, CLI) that users can carry on a USB drive. Phase 3 adds challenge-response signing, vault export/import, and credential organization. Phase 4 layers on the ScalarDL tamper-evident audit system. Phase 5 wraps the CLI in a terminal UI for guided workflows. Phase 6 delivers the desktop GUI, documentation, and security review to reach v1.0 stable.
+
+## Phases
+
+**Phase Numbering:**
+
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [ ] **Phase 1: Foundation** - Crypto primitives, memguard wrapper, shared types, and project scaffolding
+- [ ] **Phase 2: Core authenticator** - Vault, auth engines, clipboard, config, CLI with daily-use commands
+- [x] **Phase 3: Enhancements and export** - Challenge-response signing, vault export/import, credential organization (completed 2026-03-17)
+- [x] **Phase 4: Audit layer** - ScalarDL integration, offline queue, verify and history commands (completed 2026-03-18)
+- [ ] **Phase 4.1: Deploy HashStore contracts** - INSERTED: Fix contract IDs, add registration step, wire audit into TUI and GUI, E2E integration test (GitHub #6)
+- [x] **Phase 4.2: Audit verification in TUI and GUI** - INSERTED: Tamper detection and audit history views in TUI and GUI (completed 2026-03-25)
+- [x] **Phase 4.3: Collection-based audit storage** - INSERTED: Rearchitect to use ScalarDL collections for full event history with metadata (completed 2026-03-26)
+- [x] **Phase 5: Terminal UI** - Bubbletea TUI with guided setup, visual countdown, and credential management (completed 2026-03-20)
+- [ ] **Phase 6: GUI, docs, and release** - Wails desktop GUI, documentation, security review, release automation
+- [ ] **Phase 7: One-click Docker audit setup with auto-start on vault unlock** - Single-command audit setup across CLI, TUI, and GUI; Docker stack auto-starts on unlock
+- [x] **Phase 8: Audit opt-in during vault creation and auto_start config toggle** - Prompt during vault creation, `audit.auto_start` field, and settings toggle across CLI/TUI/GUI (GitHub #15) (completed 2026-04-02)
+- [x] **Phase 9: E2E Docker audit testing** - Integration tests for SetupStack/MaybeAutoStart with CI job (completed 2026-04-04)
+- [x] **Phase 10: Audit client TLS and refactoring** - TLS transport, struct-based client config, shared event builder factory, FAT32 crash test (v0.9) (completed 2026-04-15)
+- [x] **Phase 11: macOS binary signing** - Apple Developer ID codesigning and notarization in GitHub Actions (v0.9) (completed 2026-04-12)
+- [x] **Phase 12: ScalarDL 3.13 upgrade** - Upgrade Ledger and schema loader Docker images from 3.12 to 3.13 (v0.9) (completed 2026-04-14)
+- [x] **Phase 12.1: Release workflow end-to-end test** - INSERTED: Test GitHub Actions release workflow with pre-release tag, verify all artifacts (GitHub #20) (v0.9.5) (completed 2026-04-18)
+- [ ] **Phase 12.2: Screenshots and documentation polish** - INSERTED: Add GUI and TUI screenshots to README, visual polish (GitHub #21) (v1.0)
+- [ ] **Phase 12.3: UI/UX improvements - audit and critical fixes** - INSERTED: Audit history sorting, TUI Enter key fix, vault path storage warning (GitHub #24 selected items) (v0.9.5)
+- [ ] **Phase 12.4: Pre-release validation** - INSERTED: Cross-platform testing and release readiness sign-off before v0.9.5 tag (Wayland and idle timer fixes already merged) (v0.9.5)
+- [ ] **Phase 12.5: Fix audit validation** - INSERTED: Store hash values in vault at submission time for independent validation (GitHub #67) (v0.9.5)
+- [ ] **Phase 12.6: Expand audit logging** - INSERTED: Capture vault lifecycle and credential management events in audit log (GitHub #59) (v0.9.5)
+- [ ] **Phase 12.7: Audit history display improvements** - INSERTED: Sortable/filterable audit history, pagination, click-to-reveal hashes (GitHub #24) (v0.9.5)
+- [ ] **Phase 12.8: Docker lifecycle and HMAC key hardening** - INSERTED: Stop Docker containers on app close, move HMAC secret from plaintext files into encrypted vault (GitHub #52, #53) (v0.9.6)
+- [ ] **Phase 12.9: Audit server UX and PostgreSQL volume protection** - INSERTED: Surface running audit server status to users; PostgreSQL exposure window closed by #52 fix (GitHub #54, #55) (v0.9.6)
+- [ ] **Phase 13: Traceability cleanup** - Update 20 stale Pending entries in REQUIREMENTS.md to Complete (v1.0)
+- [ ] **Phase 14: v1.0 Documentation and release** - Comprehensive user documentation, contribution guides, final release (v1.0)
+
+## Phase Details
+
+### Phase 1: Foundation
+
+**Goal**: Cryptographic primitives and shared data types are implemented, tested, and enforced so that every subsequent component builds on a secure, correct foundation.
+**Depends on**: Nothing (first phase)
+**Requirements**: SECR-01, SECR-02, PLAT-04
+**Success Criteria** (what must be TRUE):
+  1. Argon2id key derivation produces correct output for known test vectors
+  2. AES-256-GCM encrypt/decrypt round-trips correctly with authenticated data
+  3. All key material is allocated via memguard outside the Go GC heap, and zeroed after use
+  4. No internal package other than `internal/crypto/guard` imports memguard directly
+  5. Project builds as a single static binary (CGO_ENABLED=0) under 20MB
+**Plans**: 2 plans
+
+Plans:
+
+- [ ] 01-01-PLAN.md -- Project scaffolding and memguard guard wrapper with TDD
+- [ ] 01-02-PLAN.md -- Crypto primitives, model types, error conventions, CLI stub, and binary size verification
+
+### Phase 2: Core authenticator
+
+**Goal**: Users can initialize an encrypted vault on a USB drive, add credentials, and generate TOTP/HOTP codes and retrieve static passwords from any machine without installing software.
+**Depends on**: Phase 1
+**Requirements**: AUTH-01, AUTH-02, AUTH-03, AUTH-04, AUTH-05, AUTH-08, AUTH-09, AUTH-10, VALT-01, VALT-02, VALT-03, VALT-04, VALT-05, VALT-06, VALT-07, VALT-08, VALT-09, SECR-03, SECR-04, SECR-05, CLIP-01, CLIP-02, CLIP-03, CLIP-04, PLAT-01, PLAT-02, PLAT-03, PLAT-05, PLAT-06, PLAT-07, PLAT-08
+**Success Criteria** (what must be TRUE):
+  1. User can run `tegata init` on a USB drive to create an encrypted vault with PIN/passphrase and receive a recovery key
+  2. User can add TOTP/HOTP credentials manually or by pasting an otpauth:// URI, and see them listed via `tegata list`
+  3. User can run `tegata code <label>` to generate a valid TOTP or HOTP code that works with the target service
+  4. User can store a static password and retrieve it to the clipboard, which auto-clears after the configured timeout
+  5. Vault auto-locks after idle timeout, PIN attempts are rate-limited, and the binary runs from USB with zero installation on Windows, macOS, and Linux
+**Plans**: 6 plans
+
+Plans:
+
+- [ ] 02-01-PLAN.md -- Vault manager: header serialization, rate limiting, create/open/unlock/save, recovery key, credential CRUD
+- [ ] 02-02-PLAN.md -- Auth engines: TOTP (RFC 6238), HOTP (RFC 4226), static password, otpauth:// URI parsing
+- [ ] 02-03-PLAN.md -- Config manager (TOML parsing with defaults) and clipboard manager (auto-clear with cancellation)
+- [ ] 02-04-PLAN.md -- CLI commands: init, add, list, remove with vault discovery and passphrase prompting helpers
+- [ ] 02-05-PLAN.md -- CLI commands: code, get, resync, bench, config show with cross-platform build verification
+- [ ] 02-06-PLAN.md -- Integration tests and human verification of full CLI workflow
+
+### Phase 3: Enhancements and export
+
+**Goal**: Users can perform challenge-response signing, back up and restore their vault, and organize credentials as their collection grows.
+**Depends on**: Phase 2
+**Requirements**: AUTH-06, AUTH-07, VALT-10, VALT-11, VALT-12, VALT-13, VALT-14, CLIP-05
+**Success Criteria** (what must be TRUE):
+  1. User can run `tegata sign <label>` with a challenge (via argument or stdin) and receive an HMAC-SHA1 or HMAC-SHA256 signed response on stdout
+  2. User can export vault to an encrypted backup file and import it on another machine to restore all credentials
+  3. User can organize credentials with groups and tags, and filter `tegata list` output accordingly
+  4. CLI command set is documented with backwards-compatibility guarantees
+**Plans**: 3 plans
+
+Plans:
+
+- [ ] 03-01-PLAN.md -- Challenge-response engine (TDD) and tegata sign command with --challenge and --clip flags
+- [ ] 03-02-PLAN.md -- Encrypted vault export/import (TDD) with tegata export and tegata import commands
+- [ ] 03-03-PLAN.md -- Tag organization, vault maintenance commands (change-passphrase, verify-recovery), and STABILITY.md
+
+### Phase 4: Audit layer
+
+**Goal**: Users can connect to a ScalarDL Ledger instance and get tamper-evident logging of every authentication operation, with offline resilience and verifiable integrity.
+**Depends on**: Phase 2
+**Requirements**: AUDT-01, AUDT-02, AUDT-03, AUDT-04, AUDT-05, AUDT-06, AUDT-07, AUDT-08, AUDT-09, AUDT-10, SECR-06, DOCS-03, DOCS-04
+**Success Criteria** (what must be TRUE):
+  1. User can run `tegata ledger setup` to configure a ScalarDL connection, and subsequent auth operations are logged to the ledger
+  2. User can run `tegata verify` to confirm the hash-chain integrity of their audit log
+  3. User can run `tegata history` to view a human-readable list of auth events, filtered by date, label, or operation type
+  4. Auth events queue locally when ScalarDL is unreachable and automatically submit when connectivity is restored
+  5. Audit log entries never contain plaintext secrets or unhashed credential identifiers
+**Plans**: 3 plans
+
+Plans:
+
+- [ ] 04-01-PLAN.md — AuthEvent struct, OfflineQueue with AES-256-GCM and hash chain, AuditConfig extension (TDD)
+- [ ] 04-02-PLAN.md — gRPC client, proto stubs, ECDSASigner, tegata ledger setup, Docker Compose, scalardl-setup.md
+- [ ] 04-03-PLAN.md — EventBuilder wired into auth commands, tegata history and tegata verify commands
+
+### Phase 4.1: Deploy HashStore contracts
+
+**Goal**: ScalarDL audit integration works end-to-end against a live HashStore instance — correct contract IDs, registration step, audit events from all interfaces (CLI, TUI, GUI), and offline queue flushing verified with an integration test.
+**Depends on**: Phase 4
+**Requirements**: AUDT-01, AUDT-02, AUDT-05, AUDT-06, AUDT-09
+**Success Criteria** (what must be TRUE):
+  1. `tegata ledger setup` connects to a Docker ScalarDL instance and registers contracts successfully
+  2. `tegata history` returns recorded authentication events from a live ScalarDL Ledger
+  3. `tegata verify` validates hash-chain integrity and reports success or tampering
+  4. TUI credential actions (code, get, sign) emit audit events when audit is configured
+  5. Desktop GUI credential actions emit audit events when audit is configured
+  6. Offline event queue flushes correctly when ScalarDL connectivity is restored
+  7. Integration test passes against a live ScalarDL Docker instance
+**Plans**: 3 plans
+
+Plans:
+
+- [x] 04.1-01-PLAN.md — Fix object.Validate schema, add contract registration to Docker Compose, enhance ledger setup
+- [x] 04.1-02-PLAN.md — Wire EventBuilder into TUI and GUI credential action handlers
+- [x] 04.1-03-PLAN.md — E2E integration tests for Put+Get+Validate and offline queue flush
+
+### Phase 5: Terminal UI
+
+**Goal**: Users who prefer a guided interface can use Tegata through an interactive terminal UI with visual feedback, without losing any CLI functionality.
+**Depends on**: Phase 3
+**Requirements**: TUIX-01, TUIX-02, TUIX-03
+**Success Criteria** (what must be TRUE):
+  1. User can launch the TUI and complete first-time vault setup through a guided wizard flow
+  2. User can view all credentials with a live TOTP countdown timer and copy codes interactively
+  3. User can add, edit, and remove credentials through the TUI without dropping to CLI commands
+**Plans**: 5 plans
+
+Plans:
+
+- [ ] 05-01-PLAN.md — Install charmbracelet dependencies and create TUI test scaffold (Wave 0)
+- [ ] 05-02-PLAN.md — Root model, styles, cobra entry point, and first-time setup wizard (TUIX-01)
+- [ ] 05-03-PLAN.md — Unlock screen, daily use main view, TOTP ticker, idle auto-lock (TUIX-02)
+- [ ] 05-04-PLAN.md — Add/remove overlays and settings overlay with 4 sub-flows (TUIX-03)
+- [ ] 05-05-PLAN.md — Human verification checkpoint: end-to-end TUI in real terminal
+
+### Phase 4.2: Audit verification in TUI and GUI
+
+**Goal**: Users can check audit log integrity and view audit history directly from the TUI and GUI without dropping to the CLI.
+**Depends on**: Phase 4.1, Phase 5, Phase 6
+**Requirements**: AUDT-05, AUDT-06
+**Success Criteria** (what must be TRUE):
+  1. TUI displays an "Audit" menu item that shows audit history and a verify action
+  2. GUI displays an audit status indicator and a verify button in the settings or audit panel
+  3. Both TUI and GUI show a clear tamper-detected warning when `tegata verify` reports an integrity violation
+  4. Audit history is viewable in both TUI and GUI with the same data as `tegata history`
+**Plans**: 2 plans
+
+Plans:
+
+- [x] 04.2-01-PLAN.md — TUI audit overlay with async history viewing and integrity verification
+- [x] 04.2-02-PLAN.md — GUI audit panel with Go backend methods, React component, and tamper warning
+
+### Phase 4.3: Rearchitect audit storage with ScalarDL collections
+
+**Goal**: Audit history shows all events with readable details (operation type, label, timestamp), not just the latest hash. Each event is individually verifiable.
+**Depends on**: Phase 4.2
+**Requirements**: AUDT-05, AUDT-06
+**Success Criteria** (what must be TRUE):
+  1. Each audit event is stored as its own ScalarDL object with metadata (operation, label hash, timestamp)
+  2. A per-entity collection tracks all event object IDs
+  3. `tegata history` lists all events with operation type, label hash, and timestamp
+  4. TUI and GUI history views show the same detailed event list
+  5. `tegata verify` validates each event individually via the collection
+  6. Multiple code generations produce multiple distinct history entries
+**Plans**: 2 plans
+
+Plans:
+
+- [x] 04.3-01-PLAN.md — Core client collection methods, CLI history and verify rewrite
+- [x] 04.3-02-PLAN.md — TUI audit overlay and GUI audit panel collection-based updates
+
+**Architecture:**
+- Store: `object.Put(eventID, hash, metadata:{operation, label_hash, timestamp})` + `collection.Add(collectionID, [eventID])`
+- List: `collection.Get(collectionID)` → all event IDs → `object.Get(each)` for hash + metadata
+- Verify: iterate collection members → `object.Validate(each)`
+- Contract IDs: `object.v1_0_0.Put`, `collection.v1_0_0.Create`, `collection.v1_0_0.Add`, `collection.v1_0_0.Get`
+- WIP stashed on `feature/deploy-hashstore-contracts` branch (`git stash list`)
+
+### Phase 6: GUI, docs, and release
+
+**Goal**: Tegata reaches v1.0 stable with a desktop GUI for non-CLI users, comprehensive documentation, and a completed security review.
+**Depends on**: Phase 4, Phase 5
+**Requirements**: GUIX-01, GUIX-02, GUIX-03, GUIX-04, SECR-07, DOCS-01, DOCS-02
+**Success Criteria** (what must be TRUE):
+  1. User can install the desktop GUI on Windows, macOS, or Linux and perform all operations available in the CLI
+  2. GUI detects and unlocks a vault on a connected USB drive without requiring manual path entry
+  3. Comprehensive user documentation, contribution guidelines, and community governance documents are published
+  4. An independent security review of cryptographic implementation, vault format, and memory handling is completed and findings addressed
+**Plans**: 7 plans
+
+Plans:
+
+- [x] 06-01-PLAN.md — Wails project scaffolding and Go adapter with unit tests
+- [x] 06-02-PLAN.md — Frontend shell: shadcn/ui, Tailwind, cinnabar theming, and layout components
+- [x] 06-03-PLAN.md — User documentation, CLI reference, security self-audit, CONTRIBUTING.md, and README
+- [x] 06-04-PLAN.md — GUI hooks, shared components, unlock view, and setup wizard
+- [x] 06-05-PLAN.md — GUI credential detail, settings panel, and App.tsx wiring
+- [x] 06-06-PLAN.md — Release automation: GitHub Actions workflow, installer configs, Makefile targets
+- [ ] 06-07-PLAN.md — Human verification checkpoint for all Phase 6 deliverables
+
+### Phase 7: One-click Docker audit setup with auto-start on vault unlock
+
+**Goal**: The ScalarDL audit layer is practically usable for all users — CLI, TUI, and GUI — via a single setup action that auto-starts the Docker stack on vault unlock.
+**Depends on**: Phase 6
+**Requirements**: TBD
+**Success Criteria** (what must be TRUE):
+  1. User can run `tegata ledger start` to complete the full Docker audit setup sequence in one command
+  2. TUI audit overlay offers "Start audit server" as a third menu item alongside View history and Verify integrity
+  3. GUI AuditPanel shows a "Start audit server" button that runs the setup sequence inline
+  4. After setup, the Docker stack starts automatically in the background when the user unlocks the vault and the ledger is unreachable
+  5. `tegata ledger stop` stops containers while preserving audit data
+  6. Users who never run setup never encounter any Docker-related behavior
+**Plans**: 6 plans
+
+Plans:
+
+- [x] 07-01-PLAN.md — Core infrastructure: audit/docker.go, config/write_audit.go, VaultPayload.VaultID, compose named volume, embed bundles
+- [x] 07-02-PLAN.md — Test scaffold (Wave 0): docker_test.go, write_audit_test.go, CLI and TUI test stubs
+- [x] 07-03-PLAN.md — CLI wiring: tegata ledger start/stop subcommands and auto-start hook in TUI and GUI unlock
+- [ ] 07-04-PLAN.md — TUI audit overlay: Start audit server menu item and viewAuditStart sub-flow
+- [ ] 07-05-PLAN.md — GUI wiring: AuditPanel Start/Stop buttons, Wails bindings
+- [ ] 07-06-PLAN.md — Human verification checkpoint for all Phase 7 deliverables
+
+### Phase 8: Audit opt-in during vault creation and auto_start config toggle
+
+**Goal**: Users are prompted to opt in to audit logging during vault creation, and can toggle auto-start from settings — closing the remaining gaps from GitHub issue #15.
+**Depends on**: Phase 7
+**Requirements**: TBD
+**Success Criteria** (what must be TRUE):
+  1. `tegata init`, TUI creation wizard, and GUI creation wizard all prompt users to optionally enable audit logging (requires Docker)
+  2. `audit.auto_start` boolean field exists in `tegata.toml` and controls whether Docker auto-start fires on unlock
+  3. `tegata config` (or equivalent), TUI settings overlay, and GUI settings panel all expose a toggle for `auto_start`
+  4. Users who decline the prompt during vault creation never see any Docker-related behavior
+**Plans**: 4 plans
+
+Plans:
+
+- [x] 08-01-PLAN.md — Config layer: AutoStart field, default logic, WriteAuditSection extension, MaybeAutoStart gate
+- [x] 08-02-PLAN.md — Vault creation opt-in: CLI init prompt, TUI wizard step 5/5, GUI wizard checkbox
+- [x] 08-03-PLAN.md — Settings toggle: tegata config set subcommand, TUI keybind, GUI settings checkbox
+- [x] 08-04-PLAN.md — Gap closure: Fix enabled=false in opt-in flows, conditional audit menu visibility, Enabled-based gating
+
+### Phase 9: End-to-end Docker audit setup verification and auto-start testing
+
+**Goal:** Docker audit setup (`SetupStack`) and auto-start (`MaybeAutoStart`) are validated end-to-end against a real Docker environment via integration tests, with a CI job to run them automatically on ubuntu-latest.
+**Requirements**: D-01, D-02, D-03, D-04, D-05, D-06
+**Depends on:** Phase 8
+**Success Criteria** (what must be TRUE):
+  1. Integration tests verify SetupStack happy path, MaybeAutoStart restart flow, and error paths against real Docker
+  2. Tests use `//go:build integration` tag and run with `go test -tags integration ./internal/audit/... -v -timeout 300s`
+  3. CI has a separate `integration-tests` job on `ubuntu-latest` that runs Docker integration tests
+  4. Any bugs surfaced by the tests are fixed inline
+**Plans:** 1 plan
+
+Plans:
+
+- [x] 09-01-PLAN.md -- Docker integration tests for SetupStack/MaybeAutoStart/error paths and CI job addition
+
+### Phase 10: Audit client TLS and refactoring
+
+**Goal**: The audit client supports TLS transport alongside HMAC authentication, `NewClientFromConfig` accepts a struct instead of 6 positional parameters, and event builder construction is deduplicated into a shared factory — closing GitHub issues #22 and #30 (v0.9).
+**Depends on**: Phase 9
+**Milestone**: v0.9 -- Security audit
+**Requirements**: AUDT-11, AUDT-12, AUDT-13, SECR-08
+**Success Criteria** (what must be TRUE):
+  1. `NewClientFromConfig` accepts `config.AuditConfig` and supports `insecure = false` with HMAC auth over TLS
+  2. All 14 call sites of `NewClientFromConfig` are updated to the struct form
+  3. A shared `audit.NewEventBuilderFromConfig` factory replaces duplicated key derivation logic in CLI and GUI
+  4. All existing unit and integration tests pass
+  5. FAT32 atomic write integration test verifies `vault.atomicWrite` recovery from simulated mid-rename failure
+**Plans**: 2 plans
+
+Plans:
+
+- [x] 10-01-PLAN.md -- TLS support in audit client, `NewClientFromConfig` struct refactor, shared `NewEventBuilderFromConfig` factory
+- [x] 10-02-PLAN.md -- FAT32 atomic write integration test (quick task)
+
+### Phase 11: macOS binary signing
+
+**Goal**: macOS release binaries are codesigned and notarized so users can run Tegata without Gatekeeper warnings or manual security overrides.
+**Depends on**: Phase 10
+**Milestone**: v0.9 -- Security audit
+**Requirements**: SECR-09
+**Success Criteria** (what must be TRUE):
+  1. GitHub Actions release workflow codesigns macOS amd64 and arm64 binaries with an Apple Developer ID certificate
+  2. Signed binaries are submitted to Apple notarization service and stapled
+  3. A freshly downloaded macOS binary passes Gatekeeper (`spctl --assess`) without user intervention
+**Plans**: 2 plans
+
+Plans:
+
+- [x] 11-01-PLAN.md -- Apple Developer ID codesigning and notarization in GitHub Actions release workflow
+
+### Phase 12: ScalarDL 3.13 upgrade
+
+**Goal**: ScalarDL Docker images are upgraded from 3.12 to 3.13, picking up 6 CVE patches and the NPE fix for the gRPC client, with all integration tests still passing.
+**Depends on**: Phase 10
+**Milestone**: v0.9 -- Security audit
+**Requirements**: AUDT-14
+**Success Criteria** (what must be TRUE):
+  1. Docker Compose files reference ScalarDL Ledger 3.13.0 and schema loader 3.13.0 images
+  2. Proto stubs are verified compatible with 3.13 (no breaking changes in wire format)
+  3. All existing integration tests (`go test -tags integration ./internal/audit/...`) pass against the 3.13 Docker stack
+  4. `tegata ledger start` and `tegata ledger setup` complete successfully with the upgraded images
+**Plans**: 2 plans
+
+Plans:
+
+- [x] 12-01-PLAN.md -- Bump ScalarDL Docker image tags to 3.13.0, verify proto compatibility, run integration tests
+
+### Phase 12.1: Release workflow end-to-end test
+
+**Goal**: The GitHub Actions release workflow produces correct artifacts for all platforms and can be reliably used to create releases. Pre-release testing validates the build pipeline before the final v1.0 release.
+**Depends on**: Phase 6 (release automation completed)
+**Milestone**: v0.9.5 -- Polish and validation
+**Requirements**: Issue #20
+**Success Criteria** (what must be TRUE):
+  1. Tag a pre-release (e.g., `v0.9.5-rc.1`) to trigger the workflow
+  2. All 5 release jobs complete successfully: cli-binaries, gui-windows, gui-macos, gui-linux, release
+  3. CLI binaries are produced for Windows (amd64), macOS (arm64, amd64), and Linux (amd64), each < 20MB
+  4. GUI installers are produced: Windows NSIS setup exe, macOS universal DMG, Linux deb/rpm
+  5. Artifact names, sizes, and checksums are reasonable
+  6. GitHub Release is created with all artifacts attached
+  7. Test download and launch CLI binary and GUI installer on at least one platform
+  8. Fix any workflow failures and re-test before tagging v1.0.0
+**Plans**: 2 plans
+
+Plans:
+
+- [x] 12.1-01-PLAN.md -- Pre-release tag workflow testing, artifact verification, and platform validation
+
+### Phase 12.2: Screenshots and documentation polish
+
+**Goal**: README displays actual application screenshots instead of placeholders, giving users a visual preview of Tegata's interface before installation.
+**Depends on**: Phase 6 (GUI complete)
+**Milestone**: v1.0 -- Stable release
+**Requirements**: Issue #21
+**Success Criteria** (what must be TRUE):
+  1. Screenshots capture: GUI unlock screen, credential list with TOTP countdown, add credential flow, audit panel, settings panel
+  2. At least one TUI screenshot showing the main credential view
+  3. Both light and dark themes are represented
+  4. Images stored in docs/images/ with proper compression (PNG or WebP)
+  5. README uses relative paths and renders correctly on GitHub
+  6. Screenshots convey the application's look and feel clearly
+**Plans**: 2 plans
+
+Plans:
+
+- [ ] 12.2-01-PLAN.md -- Capture GUI and TUI screenshots, optimize images, update README
+
+### Phase 12.3: UI/UX improvements - audit and critical fixes
+
+**Goal**: High-priority UI/UX issues are fixed to improve usability before release: audit history displays in chronological order (newest first), TUI vault path input responds to Enter key, and users are warned about local vault storage security tradeoffs.
+**Depends on**: Phase 6 (GUI complete), Phase 5 (TUI complete)
+**Milestone**: v0.9.5 -- Polish and validation
+**Requirements**: GitHub issues #38, #39, #40 (maps to TUIX-04, TUIX-05, SECR-10)
+**Success Criteria** (what must be TRUE):
+  1. Audit history displays sorted by timestamp (newest first) across CLI, TUI, and GUI (issue #38)
+  2. TUI vault path input correctly responds to Enter key to advance to passphrase screen (issue #39)
+  3. Vault creation wizard warns users about local/system drive security tradeoffs vs. removable drives (issue #40)
+  4. All UI changes are tested and verified across all three interfaces
+  5. Three separate PRs delivered (one per improvement)
+**Plans**: 3 plans (one per PR)
+
+Plans:
+
+- [x] 12.3-01-PLAN.md -- Audit history sorting (newest first) in CLI, TUI, GUI
+- [x] 12.3-02-PLAN.md -- TUI vault path input Enter key fix
+- [x] 12.3-03-PLAN.md -- Vault storage security warning (local vs. removable drives)
+
+### Phase 12.4: Pre-release validation
+
+**Goal**: Final validation before v0.9.5 release: cross-platform testing across platforms, and readiness verification. (Wayland clipboard fallback and idle timer fixes were merged early as PRs #48 and #49.)
+**Depends on**: Phases 12.1, 12.2, 12.3
+**Milestone**: v0.9.5 -- Polish and validation
+**Requirements**: Cross-platform validation sign-off
+**Success Criteria** (what must be TRUE):
+  1. ~~Wayland clipboard fallback~~ — completed via PR #48
+  2. Cross-platform testing on Windows 10+, macOS 12+, Linux (with Wayland and X11 variants)
+  3. All integration tests pass (Docker, FAT32, audit, etc.)
+  4. Release artifacts are tested on actual hardware/VMs
+  5. Release notes are written summarizing v0.9.5 improvements
+  6. Go-ahead decision made for v1.0 release
+**Plans**: 2 plans
+
+Plans:
+
+- [ ] 12.4-01-PLAN.md -- Wayland clipboard fallback, cross-platform validation, release readiness
+
+### Phase 12.5: Fix audit validation — store hash values independently
+
+**Goal**: Audit integrity verification correctly detects real tampering by storing expected hash values in the vault at submission time, not fetching them from ScalarDL.
+**Depends on**: Phase 4.3 (collection-based audit storage)
+**Milestone**: v0.9.5 -- Polish and validation
+**Requirements**: GitHub issue #67
+**Success Criteria** (what must be TRUE):
+  1. At submission time, the expected hash value for each audit event is written to the vault, keyed by event ID
+  2. At validation time, expected hash values are read from the vault and passed to `object.v1_0_0.Validate` instead of fetching them from ScalarDL
+  3. Manually tampering with a record's `hash_value` in the ScalarDL PostgreSQL database causes the GUI to show the red "Tamper detected" banner
+  4. Credentials whose records have not been tampered with continue to show "Integrity verified"
+  5. Vault-side audit record store is zeroed from memory after use
+**Plans**: 2 plans
+
+Plans:
+
+- [x] 12.5-01-PLAN.md -- Add AuditHashes to vault model, update Validate/Submit signatures, update VerifyAll/VerifyByLabelHash
+- [ ] 12.5-02-PLAN.md -- Wire CLI, GUI, TUI callers with vault hashes, EventBuilder callbacks, memory zeroing
+
+### Phase 12.6: Expand audit logging to vault lifecycle and credential management events
+
+**Goal**: The audit log captures vault unlock/lock events and credential create/edit/delete events in addition to authentication operations, providing a complete tamper-evident audit trail.
+**Depends on**: Phase 4.3 (collection-based audit storage), Phase 12.5
+**Milestone**: v0.9.5 -- Polish and validation
+**Requirements**: GitHub issue #59
+**Success Criteria** (what must be TRUE):
+  1. Vault unlock and lock (including auto-lock) events are logged with timestamp and host machine fingerprint hash
+  2. Credential created, edited, and deleted events are logged with timestamp, label hash, issuer hash, and host fingerprint hash
+  3. All new events follow the existing privacy model (labels, service names, host identifiers are hashed)
+  4. All new events are submitted to ScalarDL when audit is enabled, and queued locally when unreachable
+  5. `tegata history` displays and can filter the new event types
+**Plans**: 2 plans
+
+Plans:
+
+- [ ] 12.6-01-PLAN.md -- Extend AuthEvent struct and EventBuilder for lifecycle events; update history command
+
+### Phase 12.7: Audit history display improvements
+
+**Goal**: Audit history is sortable by column, filterable by operation type and date range, paginated for long lists, and hash values are click-to-reveal with auto-copy.
+**Depends on**: Phase 4.3 (collection-based audit storage)
+**Milestone**: v0.9.5 -- Polish and validation
+**Requirements**: GitHub issue #24
+**Success Criteria** (what must be TRUE):
+  1. GUI audit panel supports column sorting (click header toggles asc/desc) and operation type dropdown filter and date range picker
+  2. CLI supports `--sort`, `--order`, `--type`, and `--limit` flags on `tegata history`
+  3. Long event lists are paginated or virtualized in GUI; scrollable in TUI; limited with `--limit` in CLI
+  4. GUI: clicking a truncated hash reveals the full value and copies it to clipboard; TUI: Enter/`c` copies full hash with status message
+**Plans**: 2 plans
+
+Plans:
+
+- [ ] 12.7-01-PLAN.md -- Column sorting, operation filter, date range, pagination, hash click-to-reveal across CLI/TUI/GUI
+
+### Phase 12.8: Docker lifecycle and HMAC key hardening
+
+**Goal**: Docker containers stop when the app closes (eliminating unattended audit server exposure), and the HMAC secret key is moved from plaintext disk files into the encrypted vault.
+**Depends on**: Phase 7 (Docker audit setup)
+**Milestone**: v0.9.6 -- Security hardening
+**Requirements**: GitHub issues #52, #53
+**Success Criteria** (what must be TRUE):
+  1. Closing Tegata GUI stops all ScalarDL and PostgreSQL Docker containers
+  2. HMAC secret key is no longer stored in `tegata.toml` or any plaintext file on disk
+  3. HMAC secret key is stored in the encrypted vault and loaded into memory only when needed
+  4. Existing audit functionality (submit, validate, history) continues to work correctly
+  5. Issue #55 (PostgreSQL volume exposure) is resolved as a consequence of Docker stop-on-close
+**Plans**: 2 plans
+
+Plans:
+
+- [ ] 12.8-01-PLAN.md -- Stop Docker containers on app close (GUI shutdown hook, OS signal handler)
+- [ ] 12.8-02-PLAN.md -- Move HMAC secret key from plaintext tegata.toml into encrypted vault
+
+### Phase 12.9: Audit server UX and PostgreSQL volume protection
+
+**Goal**: Users are informed when the audit server is running after app close, and the PostgreSQL volume exposure window is eliminated (via Phase 12.8's Docker stop-on-close fix).
+**Depends on**: Phase 12.8
+**Milestone**: v0.9.6 -- Security hardening
+**Requirements**: GitHub issues #54, #55
+**Success Criteria** (what must be TRUE):
+  1. When closing Tegata with the audit server enabled, the user sees a notification or status indicator that Docker containers are stopping
+  2. If Docker stop fails, the user is warned that containers may still be running
+  3. Issue #55 (PostgreSQL named volume with unencrypted audit data accessible while containers run) is closed as a consequence of Phase 12.8
+**Plans**: 2 plans
+
+Plans:
+
+- [ ] 12.9-01-PLAN.md -- UX indicator for audit server shutdown state on app close
+
+### Phase 13: Traceability cleanup
+
+**Goal**: The REQUIREMENTS.md traceability table accurately reflects project status, with all completed requirements marked as such.
+**Depends on**: Phase 10
+**Milestone**: v1.0 -- Stable release
+**Requirements**: DOCS-05
+**Success Criteria** (what must be TRUE):
+  1. All 20 stale "Pending" entries in the traceability table that correspond to implemented features are updated to "Complete"
+  2. No requirement marked "Complete" lacks a corresponding implemented feature in the codebase
+**Plans**: 2 plans
+
+Plans:
+
+- [ ] 13-01-PLAN.md -- Audit traceability table against codebase and update 20 stale Pending entries to Complete
+
+## Progress
+
+**Execution Order:**
+
+Phases execute in numeric order: 1 → 2 → 3 → 4 → 4.1 → 5 → 6 → 4.2 → 4.3 → 7 → 8 → 9 → 10 → 11 → 12 → [v0.9 complete] → 12.1 → 12.2 → 12.3 → 12.4 → 12.5 → 12.6 → 12.7 → [v0.9.5 complete] → 12.8 → 12.9 → [v0.9.6 complete] → 13 → 14 → [v1.0 stable]
+
+Note: Phase 3 and Phase 4 depend on Phase 2 but not on each other. Phases 11, 12 depend on Phase 10. Phases 12.1-12.7 are v0.9.5 insertions; phases 12.8-12.9 are v0.9.6 security hardening insertions. Phases 13-14 target v1.0 stable release.
+
+| Phase                              | Plans Complete | Status      | Completed  |
+|------------------------------------|----------------|-------------|------------|
+| 1. Foundation                      | 2/2            | Complete    | 2026-03-16 |
+| 2. Core authenticator              | 6/6            | Complete    | 2026-03-17 |
+| 3. Enhancements and export         | 3/3            | Complete    | 2026-03-17 |
+| 4. Audit layer                     | 3/3            | Complete    | 2026-03-18 |
+| 4.1 Deploy HashStore               | 3/3            | Complete    | 2026-03-24 |
+| 4.2 Audit in TUI/GUI              | 2/2            | Complete    | 2026-03-25 |
+| 4.3 Collection storage             | 2/2            | Complete    | 2026-03-26 |
+| 5. Terminal UI                     | 5/5            | Complete    | 2026-03-20 |
+| 6. GUI, docs, and release          | 7/7            | Complete    | 2026-03-29 |
+| 7. One-click Docker audit setup    | 6/6            | Complete    | 2026-03-29 |
+| 8. Audit opt-in and auto_start     | 4/4            | Complete    | 2026-04-02 |
+| 9. E2E Docker audit testing        | 1/1            | Complete    | 2026-04-04 |
+| 10. Audit client TLS and refactor  | 2/2            | Complete    | 2026-04-15 |
+| 11. macOS binary signing           | 1/1            | Complete    | 2026-04-12 |
+| 12. ScalarDL 3.13 upgrade          | 1/1            | Complete    | 2026-04-14 |
+| **v0.9 Security audit milestone complete** | — | — | — |
+| 12.1 Release workflow testing      | 1/1            | Complete    | 2026-04-18 |
+| 12.3 UI/UX audit and fixes         | 3/3            | Complete    | 2026-04-19 |
+| 12.4 Pre-release validation        | 0/1            | Not started | -          |
+| 12.5 Fix audit validation          | 1/2 | In Progress|  |
+| 12.6 Audit lifecycle events        | 0/1            | Not started | -          |
+| 12.7 Audit history improvements    | 0/1            | Not started | -          |
+| **v0.9.5 Polish and validation milestone target** | — | — | — |
+| 12.8 Docker lifecycle + HMAC key   | 0/2            | Not started | -          |
+| 12.9 Audit server UX + Postgres    | 0/1            | Not started | -          |
+| **v0.9.6 Security hardening milestone target** | — | — | — |
+| 12.2 Screenshots and polish        | 0/1            | Not started | -          |
+| 13. Traceability cleanup           | 0/1            | Not started | -          |
+| 14. v1.0 Documentation and release | 0/1            | Not started | -          |
+| **v1.0 Stable release milestone target** | — | — | — |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,115 @@
+---
+gsd_state_version: 1.0
+milestone: v1.0
+milestone_name: milestone
+status: executing
+last_updated: "2026-04-22T00:24:02.005Z"
+last_activity: 2026-04-22
+progress:
+  total_phases: 25
+  completed_phases: 16
+  total_plans: 53
+  completed_plans: 52
+---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-04-16)
+
+**Core value:** Users can carry encrypted authentication credentials on a USB drive and generate codes on any machine without installing software -- a portable, auditable authenticator that works offline.
+**Current focus:** Phase 12.5 — fix-audit-validation-store-hash-values-independently
+
+## Current Position
+
+Phase: 12.5 (fix-audit-validation-store-hash-values-independently) — EXECUTING
+Plan: 2 of 2
+Status: Ready to execute
+Last activity: 2026-04-22
+
+## Performance Metrics
+
+**Velocity:**
+
+- Total plans completed: 9
+- Average duration: ~5min
+- Total execution time: ~0.7 hours
+
+**By Phase:**
+
+| Phase | Plans | Total  | Avg/Plan |
+|-------|-------|--------|----------|
+| 01    | 2/2   | 9min   | 4.5min   |
+| 02    | 6/6   | ~30min | ~5min    |
+| 03    | 3/?   | ~34min | ~11min   |
+
+*Updated after each plan completion*
+| Phase 03 P02 | 6min  | 3 tasks | 6 files |
+| Phase 03 P03 | 18min | 3 tasks | 8 files |
+| Phase 04-audit-layer P01 | 5min  | 2 tasks | 8 files  |
+| Phase 04-audit-layer P02 | 30min | 3 tasks | 14 files |
+| Phase 04-audit-layer P03 | 20 | 2 tasks | 10 files |
+| Phase 05-terminal-ui P01 | 4 | 2 tasks | 3 files |
+| Phase 05-terminal-ui P02 | 25 | 2 tasks | 10 files |
+| Phase 05-terminal-ui P03 | 6 | 2 tasks | 4 files |
+| Phase 05-terminal-ui P04 | 25 | 2 tasks | 4 files |
+| Phase 06-gui-docs-and-release P03 | 7min | 2 tasks | 5 files |
+| Phase 04.1 P01 | 9min | 2 tasks | 8 files |
+| Phase 04.1 P02 | 10min | 2 tasks | 6 files |
+| Phase 04.1 P03 | 2min | 1 tasks | 1 files |
+| Phase 07 P02 | 13min | 2 tasks | 7 files |
+| Phase 07 P01 | 14min | 3 tasks | 18 files |
+| Phase 07 P03 | 17min | 2 tasks | 3 files |
+| Phase 08 P01 | 3 | 2 tasks | 5 files |
+| Phase 08 P03 | 8min | 2 tasks | 5 files |
+| Phase 08 P02 | 46min | 2 tasks | 6 files |
+| Phase 08 P04 | 2min | 2 tasks | 8 files |
+| Phase 11-macos-binary-signing P01 | 5min | 2 tasks | 4 files |
+| Phase 12.3-ui-ux-improvements P01 | 2min | 1 task | 2 files |
+| Phase 12.5 P01 | 6min | 2 tasks | 9 files |
+
+## Accumulated Context
+
+### Roadmap Evolution
+
+- Phase 7 added: One-click Docker audit setup with auto-start on vault unlock
+- Phase 8 added: Audit opt-in during vault creation and auto_start config toggle (closes remaining gaps from GitHub #15)
+- Phase 9 completed: End-to-end Docker audit setup verification and auto-start testing with integration tests and CI job
+- Phase 10-13 added: v0.9 milestone roadmap (TLS+refactor, macOS signing, ScalarDL 3.13, traceability cleanup)
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- Go language chosen over Rust (faster dev velocity, simpler cross-compilation)
+- JSON vault format over SQLite (no CGO dependency)
+- memguard for guarded memory (only imported via internal/crypto/guard wrapper)
+- Go version 1.25.0 in go.mod (x/crypto v0.49.0 requires >= 1.25.0; CI auto-downloads toolchain)
+- [Phase 11-macos-binary-signing]: GUI and CLI share same entitlements; gui-macos uploads unsigned .app with DMG creation in macos-signing job
+- [Phase 12.3-01]: Audit history sorting implemented at FetchHistory level (audit client) for consistency across CLI, TUI, GUI
+- [Phase 12.5]: Validate no longer calls Get -- expectedHash comes from vault, breaking circular trust
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- FAT32 atomic write on Windows needs integration testing with real FAT32 disk image (Phase 10, plan 10-02)
+- atotto/clipboard does not support Wayland; needs graceful fallback (Phase 2)
+
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 1 | Add frontend component and hook tests for desktop GUI | 2026-03-22 | e56eabf | [1-add-frontend-component-and-hook-tests-fo](./quick/1-add-frontend-component-and-hook-tests-fo/) |
+
+## Session Continuity
+
+Last session: 2026-04-22T00:24:02.000Z
+
+- Mapped all 6 GitHub milestone issues to 3 GSD phases (12.3, 12.4) + 3 quick tasks
+- Updated PROJECT.md and REQUIREMENTS.md with approach notes
+- Ready to begin Phase 12.3 planning

--- a/.planning/phases/12.5-fix-audit-validation-store-hash-values-independently/12.5-01-SUMMARY.md
+++ b/.planning/phases/12.5-fix-audit-validation-store-hash-values-independently/12.5-01-SUMMARY.md
@@ -1,0 +1,142 @@
+---
+phase: 12.5-fix-audit-validation-store-hash-values-independently
+plan: 01
+subsystem: audit
+tags: [scalardl, sha256, vault, hash-chain, integrity]
+
+# Dependency graph
+requires:
+  - phase: 04.3-rearchitect-audit-storage-with-scalardl-collections
+    provides: Collection-based audit storage and Validate contract flow
+provides:
+  - AuditHashes field on VaultPayload for independent hash storage
+  - Validate accepts caller-supplied expectedHash (no Get call)
+  - Submit returns computed hash value for vault persistence
+  - VerifyAll and VerifyByLabelHash accept vaultHashes parameter
+  - OnHashStored callback on EventBuilder for vault write after submit
+  - Skipped field on VerifyResult for pre-existing events
+affects: [12.5-02, cmd/tegata, cmd/tegata-gui]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [vault-supplied expected hashes for validation, callback-based hash persistence]
+
+key-files:
+  created: []
+  modified:
+    - pkg/model/vault.go
+    - internal/audit/client.go
+    - internal/audit/history.go
+    - internal/audit/builder.go
+    - internal/audit/queue.go
+    - internal/audit/history_test.go
+    - internal/audit/builder_test.go
+    - internal/audit/client_test.go
+    - internal/audit/queue_test.go
+
+key-decisions:
+  - "Validate no longer calls Get -- expectedHash comes from vault, breaking circular trust"
+  - "Pre-existing events (no vault hash) are skipped, not faulted"
+  - "OnHashStored callback on EventBuilder for best-effort vault persistence after Submit"
+
+patterns-established:
+  - "Vault-supplied hashes: callers pass vaultHashes map to VerifyAll/VerifyByLabelHash"
+  - "Callback pattern: OnHashStored func on EventBuilder for post-submit side effects"
+
+requirements-completed: ["GitHub issue #67"]
+
+# Metrics
+duration: 6min
+completed: 2026-04-22
+---
+
+# Phase 12.5 Plan 01: Audit validation with independent hash storage Summary
+
+**Break circular trust in audit validation by storing expected hashes in vault and passing them to Validate instead of fetching from ScalarDL**
+
+## Performance
+
+- **Duration:** 6 min
+- **Started:** 2026-04-22T00:16:20Z
+- **Completed:** 2026-04-22T00:22:47Z
+- **Tasks:** 2
+- **Files modified:** 9
+
+## Accomplishments
+
+- Added AuditHashes map to VaultPayload for storing event hash values independently of ScalarDL
+- Changed Validate to accept caller-supplied expectedHash, eliminating the Get call that created circular trust
+- Changed Submit to return the computed hash value so callers can persist it in the vault
+- Updated VerifyAll and VerifyByLabelHash to accept vaultHashes and skip pre-existing events
+- Added OnHashStored callback to EventBuilder for vault persistence after successful Submit
+- All internal/audit tests pass including new TestVerifyAll_SkipsPreExistingEvents
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add AuditHashes to VaultPayload and change Validate signature** - `0484d58`
+2. **Task 2: Update VerifyAll, VerifyByLabelHash, EventBuilder, and all tests** - `022bea6`
+
+## Files Created/Modified
+
+- `pkg/model/vault.go` - Added AuditHashes map[string]string field with omitempty
+- `internal/audit/client.go` - Changed Validate signature (expectedHash param), Submit returns (string, error)
+- `internal/audit/history.go` - Added vaultHashes param to VerifyAll/VerifyByLabelHash, Skipped field on VerifyResult
+- `internal/audit/builder.go` - Added OnHashStored callback, updated Submit call handling
+- `internal/audit/queue.go` - Updated Submitter interface and Flush to match new Submit signature
+- `internal/audit/history_test.go` - Updated mock, all call sites, added TestVerifyAll_SkipsPreExistingEvents
+- `internal/audit/builder_test.go` - Updated mockSubmitter to return (string, error)
+- `internal/audit/client_test.go` - Rewrote ValidateArgSchema test, replaced ValidateEmptyRecords with ValidateTampered
+- `internal/audit/queue_test.go` - Updated mockSubmitter to return (string, error)
+
+## Decisions Made
+
+- Validate no longer calls Get -- the expectedHash parameter comes from the vault, not from ScalarDL. This breaks the circular trust where the system being validated also supplied the expected values.
+- Pre-existing events (those without a vault hash entry) are skipped rather than faulted, tracked via the new Skipped field on VerifyResult (per D-09).
+- OnHashStored callback on EventBuilder is best-effort: panics are caught and logged, and failures do not prevent the Submit from succeeding (per D-14).
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Updated Submitter interface in queue.go**
+
+- **Found during:** Task 1
+- **Issue:** The Submitter interface in queue.go also needed updating to return (string, error) since it mirrors the Client.Submit signature
+- **Fix:** Updated Submitter.Submit signature and Queue.Flush to handle (string, error)
+- **Files modified:** internal/audit/queue.go
+- **Verification:** go vet passes
+- **Committed in:** 0484d58
+
+**2. [Rule 3 - Blocking] Updated mockSubmitter in queue_test.go**
+
+- **Found during:** Task 2
+- **Issue:** queue_test.go had its own mockSubmitter that did not match the updated Submitter interface
+- **Fix:** Updated queue_test.go mockSubmitter.Submit to return (string, error)
+- **Files modified:** internal/audit/queue_test.go
+- **Verification:** go test passes
+- **Committed in:** 022bea6
+
+---
+
+**Total deviations:** 2 auto-fixed (2 blocking)
+**Impact on plan:** Both were necessary to satisfy the updated interface. No scope creep.
+
+## Issues Encountered
+
+None
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Callers in cmd/tegata and cmd/tegata-gui have expected compilation errors (VerifyAll/VerifyByLabelHash now require vaultHashes parameter)
+- Plan 02 will update these callers to pass VaultPayload.AuditHashes to the verification functions
+
+---
+*Phase: 12.5-fix-audit-validation-store-hash-values-independently*
+*Completed: 2026-04-22*

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -368,10 +368,25 @@ func (a *App) GenerateTOTP(label string) (*TOTPResult, error) {
 	}
 
 	code, remaining := auth.GenerateTOTP(secret, time.Now(), period, digits, cred.Algorithm)
-	if a.builder != nil {
-		_ = a.builder.LogEvent("totp", cred.Label, cred.Issuer, audit.Hostname(), true)
-	}
 	return &TOTPResult{Code: code, Remaining: remaining}, nil
+}
+
+// RecordTOTPUsed logs an audit event for a TOTP credential. It is called
+// explicitly by the frontend when the user copies a TOTP code, not on every
+// automatic code refresh.
+func (a *App) RecordTOTPUsed(label string) error {
+	if a.vault == nil {
+		return fmt.Errorf("vault is locked")
+	}
+	a.resetIdle()
+	if a.builder == nil {
+		return nil
+	}
+	cred, err := a.vault.GetCredential(label)
+	if err != nil {
+		return err
+	}
+	return a.builder.LogEvent("totp", cred.Label, cred.Issuer, audit.Hostname(), true)
 }
 
 // GenerateHOTP generates an HOTP code for the credential with the given label.

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base32"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -216,6 +217,16 @@ func (a *App) UnlockVault(path, passphrase string) error {
 		_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: audit unavailable: %v\n", builderErr)
 	}
 	a.builder = builder
+
+	// Wire OnHashStored so each submitted audit event's hash is persisted to
+	// the vault for independent verification (D-15).
+	if a.builder != nil {
+		a.builder.OnHashStored = func(eventID, hashValue string) {
+			if err := a.vault.SetAuditHash(eventID, hashValue); err != nil {
+				slog.Error("failed to store audit hash in vault", "err", err)
+			}
+		}
+	}
 
 	// Zero passphrase AFTER builder construction.
 	zeroBytes(passBytes)
@@ -707,6 +718,7 @@ type AuditHistoryRecord struct {
 type AuditVerifyResult struct {
 	Valid       bool   `json:"valid"`
 	EventCount  int    `json:"event_count"`
+	Skipped     int    `json:"skipped,omitempty"`
 	ErrorDetail string `json:"error_detail,omitempty"`
 }
 
@@ -774,8 +786,11 @@ func (a *App) VerifyCredentialAuditLog(label string) (*AuditVerifyResult, error)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	hashes := a.vault.AuditHashes()
+	defer vault.ZeroAuditHashes(hashes)
+
 	labelHash := audit.HashString(label)
-	result, err := audit.VerifyByLabelHash(ctx, client, a.config.Audit.EntityID, labelHash)
+	result, err := audit.VerifyByLabelHash(ctx, client, a.config.Audit.EntityID, labelHash, hashes)
 	if err != nil {
 		return nil, err
 	}
@@ -783,6 +798,7 @@ func (a *App) VerifyCredentialAuditLog(label string) (*AuditVerifyResult, error)
 	return &AuditVerifyResult{
 		Valid:       result.Valid,
 		EventCount:  result.EventCount,
+		Skipped:     result.Skipped,
 		ErrorDetail: result.ErrorDetail,
 	}, nil
 }
@@ -803,7 +819,10 @@ func (a *App) VerifyAuditLog() (*AuditVerifyResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	result, err := audit.VerifyAll(ctx, client, a.config.Audit.EntityID)
+	hashes := a.vault.AuditHashes()
+	defer vault.ZeroAuditHashes(hashes)
+
+	result, err := audit.VerifyAll(ctx, client, a.config.Audit.EntityID, hashes)
 	if err != nil {
 		return nil, err
 	}
@@ -811,6 +830,7 @@ func (a *App) VerifyAuditLog() (*AuditVerifyResult, error) {
 	return &AuditVerifyResult{
 		Valid:       result.Valid,
 		EventCount:  result.EventCount,
+		Skipped:     result.Skipped,
 		ErrorDetail: result.ErrorDetail,
 	}, nil
 }

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -716,10 +716,10 @@ type AuditHistoryRecord struct {
 
 // AuditVerifyResult is the JSON-serializable shape returned by VerifyAuditLog.
 type AuditVerifyResult struct {
-	Valid       bool   `json:"valid"`
-	EventCount  int    `json:"event_count"`
-	Skipped     int    `json:"skipped,omitempty"`
-	ErrorDetail string `json:"error_detail,omitempty"`
+	Valid       bool     `json:"valid"`
+	EventCount  int      `json:"event_count"`
+	Skipped     int      `json:"skipped,omitempty"`
+	Faults      []string `json:"faults,omitempty"`
 }
 
 // IsAuditEnabled returns whether audit logging is configured and enabled.
@@ -799,7 +799,7 @@ func (a *App) VerifyCredentialAuditLog(label string) (*AuditVerifyResult, error)
 		Valid:       result.Valid,
 		EventCount:  result.EventCount,
 		Skipped:     result.Skipped,
-		ErrorDetail: result.ErrorDetail,
+		Faults:      result.Faults,
 	}, nil
 }
 
@@ -831,7 +831,7 @@ func (a *App) VerifyAuditLog() (*AuditVerifyResult, error) {
 		Valid:       result.Valid,
 		EventCount:  result.EventCount,
 		Skipped:     result.Skipped,
-		ErrorDetail: result.ErrorDetail,
+		Faults:      result.Faults,
 	}, nil
 }
 

--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -79,6 +79,7 @@ function App() {
       const result = await WailsApp.GenerateTOTP(label)
       if (result?.code) {
         await navigator.clipboard.writeText(result.code)
+        WailsApp.RecordTOTPUsed(label).catch(() => {})
       }
     } catch (err) {
       console.error("Failed to copy code:", err)

--- a/cmd/tegata-gui/frontend/src/components/audit/AuditPanel.test.tsx
+++ b/cmd/tegata-gui/frontend/src/components/audit/AuditPanel.test.tsx
@@ -55,19 +55,19 @@ describe("AuditPanel", () => {
     })
   })
 
-  it("shows tamper detected warning", async () => {
+  it("shows tamper detected warning with per-event detail", async () => {
     vi.mocked(App.VerifyAuditLog).mockResolvedValue({
       valid: false,
       event_count: 2,
-      error_detail: "hash mismatch at version 1",
+      faults: ["tegata-abc12345-0000-0000-0000-000000000000: record hash has been altered"],
     })
 
     render(<AuditPanel open={true} onClose={() => {}} />)
     await userEvent.click(screen.getByText("Verify integrity"))
 
     await waitFor(() => {
-      expect(screen.getByText(/TAMPER DETECTED/)).toBeInTheDocument()
-      expect(screen.getByText(/hash mismatch/)).toBeInTheDocument()
+      expect(screen.getByText(/TAMPERING DETECTED/)).toBeInTheDocument()
+      expect(screen.getByText(/record hash has been altered/)).toBeInTheDocument()
     })
   })
 

--- a/cmd/tegata-gui/frontend/src/components/audit/AuditPanel.tsx
+++ b/cmd/tegata-gui/frontend/src/components/audit/AuditPanel.tsx
@@ -6,6 +6,17 @@ import { App } from "@/lib/wails"
 import type { AuditHistoryRecord, AuditVerifyResult } from "@/lib/types"
 import { cn, formatError, hashString } from "@/lib/utils"
 
+function formatFault(f: string): string {
+  const idx = f.indexOf(": ")
+  if (idx < 0) return f
+  const id = f.slice(0, idx)
+  const detail = f.slice(idx + 2)
+  if (detail.startsWith("error: ")) {
+    return `Verification error for record ${id}: ${detail.slice(7)}`
+  }
+  return `The ${detail} for record ${id}`
+}
+
 const operationLabels: Record<string, string> = {
   totp: "TOTP",
   hotp: "HOTP",
@@ -146,11 +157,22 @@ export function AuditPanel({ open, onClose }: AuditPanelProps) {
                     </div>
                   )
                 ) : (
-                  <div className="flex items-center gap-2">
-                    <AlertTriangle className="h-4 w-4 text-red-600 dark:text-red-400" />
-                    <p className="text-sm font-semibold text-red-700 dark:text-red-300">
-                      TAMPER DETECTED: {verifyResult.error_detail}
-                    </p>
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <AlertTriangle className="h-4 w-4 text-red-600 dark:text-red-400" />
+                      <p className="text-sm font-semibold text-red-700 dark:text-red-300">
+                        TAMPERING DETECTED
+                      </p>
+                    </div>
+                    {verifyResult.faults && verifyResult.faults.length > 0 && (
+                      <ul className="ml-6 space-y-0.5">
+                        {verifyResult.faults.map((f, i) => (
+                          <li key={i} className="text-sm text-red-700 dark:text-red-300">
+                            {formatFault(f)}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                   </div>
                 )}
               </div>

--- a/cmd/tegata-gui/frontend/src/components/credentials/CredentialDetail.test.tsx
+++ b/cmd/tegata-gui/frontend/src/components/credentials/CredentialDetail.test.tsx
@@ -83,9 +83,9 @@ describe("CredentialDetail", () => {
     // Click the remove button to open the confirmation dialog
     await user.click(screen.getByText("Remove credential"))
 
-    // Type "DELETE" in the confirmation input
-    const confirmInput = screen.getByPlaceholderText('Type "DELETE" to confirm')
-    await user.type(confirmInput, "DELETE")
+    // Type "REMOVE" in the confirmation input
+    const confirmInput = screen.getByPlaceholderText('Type "REMOVE" to confirm')
+    await user.type(confirmInput, "REMOVE")
 
     // Click the Remove button in the dialog
     await user.click(screen.getByRole("button", { name: "Remove" }))

--- a/cmd/tegata-gui/frontend/src/components/credentials/CredentialDetail.tsx
+++ b/cmd/tegata-gui/frontend/src/components/credentials/CredentialDetail.tsx
@@ -253,16 +253,16 @@ export function CredentialDetail({ credential, onRemove, auditEnabled = false }:
           <DialogHeader>
             <DialogTitle>Remove credential?</DialogTitle>
             <DialogDescription>
-              This action cannot be undone. Type <span className="font-mono font-semibold">DELETE</span> to confirm removal of "{credential.label}".
+              This action cannot be undone. Type <span className="font-mono font-semibold">REMOVE</span> to confirm removal of "{credential.label}".
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <Input
-              placeholder='Type "DELETE" to confirm'
+              placeholder='Type "REMOVE" to confirm'
               value={deleteConfirmInput}
               onChange={(e) => setDeleteConfirmInput(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && deleteConfirmInput === "DELETE") {
+                if (e.key === "Enter" && deleteConfirmInput === "REMOVE") {
                   confirmDelete()
                 }
               }}
@@ -281,7 +281,7 @@ export function CredentialDetail({ credential, onRemove, auditEnabled = false }:
             <Button
               variant="destructive"
               onClick={confirmDelete}
-              disabled={deleteConfirmInput !== "DELETE"}
+              disabled={deleteConfirmInput !== "REMOVE"}
             >
               Remove
             </Button>

--- a/cmd/tegata-gui/frontend/src/components/credentials/CredentialDetail.tsx
+++ b/cmd/tegata-gui/frontend/src/components/credentials/CredentialDetail.tsx
@@ -334,6 +334,7 @@ function TOTPView({ credential, onUsed }: { credential: Credential; onUsed: () =
         copied={copied}
         onCopy={() => {
           navigator.clipboard.writeText(totp.code)
+          App.RecordTOTPUsed(credential.label).catch(() => {})
           setCopied(true)
           onUsed()
           setTimeout(() => setCopied(false), 2000)

--- a/cmd/tegata-gui/frontend/src/components/layout/Sidebar.test.tsx
+++ b/cmd/tegata-gui/frontend/src/components/layout/Sidebar.test.tsx
@@ -60,7 +60,7 @@ describe("Sidebar bulk deletion", () => {
     await user.click(screen.getByText("Remove multiple"))
 
     // Done button appears and type badges are hidden in selection mode
-    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
   })
 
   it("right-clicked credential is pre-selected when entering selection mode", async () => {
@@ -80,9 +80,9 @@ describe("Sidebar bulk deletion", () => {
 
     rightClickCred("GitHub")
     await user.click(screen.getByText("Remove multiple"))
-    await user.click(screen.getByRole("button", { name: "Done" }))
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
 
-    expect(screen.queryByRole("button", { name: "Done" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
     expect(screen.queryByText(/Remove \d+ selected/)).not.toBeInTheDocument()
   })
 

--- a/cmd/tegata-gui/frontend/src/components/layout/Sidebar.test.tsx
+++ b/cmd/tegata-gui/frontend/src/components/layout/Sidebar.test.tsx
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { Sidebar } from "./Sidebar"
+import type { Credential } from "@/lib/types"
+
+const cred1: Credential = {
+  id: "cred-a",
+  label: "GitHub",
+  issuer: "GitHub Inc",
+  type: "totp",
+  algorithm: "SHA1",
+  digits: 6,
+  period: 30,
+  counter: 0,
+  tags: [],
+  notes: "",
+}
+
+const cred2: Credential = {
+  id: "cred-b",
+  label: "AWS",
+  issuer: "Amazon",
+  type: "totp",
+  algorithm: "SHA1",
+  digits: 6,
+  period: 30,
+  counter: 0,
+  tags: [],
+  notes: "",
+}
+
+function makeProps(overrides: Partial<Parameters<typeof Sidebar>[0]> = {}) {
+  return {
+    credentials: [cred1, cred2],
+    selectedId: null,
+    onSelect: vi.fn(),
+    searchQuery: "",
+    onSearchChange: vi.fn(),
+    onAddClick: vi.fn(),
+    onCopyCode: vi.fn(),
+    onCopyPassword: vi.fn(),
+    onRemove: vi.fn(),
+    ...overrides,
+  }
+}
+
+/** Right-clicks the credential button containing the given label text. */
+function rightClickCred(label: string) {
+  const btn = screen.getByText(label).closest("button")!
+  fireEvent.contextMenu(btn)
+}
+
+describe("Sidebar bulk deletion", () => {
+  it("'Remove multiple' in context menu enters selection mode", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar {...makeProps()} />)
+
+    rightClickCred("GitHub")
+    await user.click(screen.getByText("Remove multiple"))
+
+    // Done button appears and type badges are hidden in selection mode
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument()
+  })
+
+  it("right-clicked credential is pre-selected when entering selection mode", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar {...makeProps()} />)
+
+    rightClickCred("GitHub")
+    await user.click(screen.getByText("Remove multiple"))
+
+    // One credential selected → bulk remove button is visible
+    expect(screen.getByText(/Remove 1 selected/)).toBeInTheDocument()
+  })
+
+  it("Done button exits selection mode and clears selection", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar {...makeProps()} />)
+
+    rightClickCred("GitHub")
+    await user.click(screen.getByText("Remove multiple"))
+    await user.click(screen.getByRole("button", { name: "Done" }))
+
+    expect(screen.queryByRole("button", { name: "Done" })).not.toBeInTheDocument()
+    expect(screen.queryByText(/Remove \d+ selected/)).not.toBeInTheDocument()
+  })
+
+  it("clicking a credential in selection mode toggles its checkbox", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar {...makeProps()} />)
+
+    rightClickCred("GitHub")
+    await user.click(screen.getByText("Remove multiple"))
+
+    // Select AWS as well — count goes from 1 to 2
+    await user.click(screen.getByText("AWS").closest("button")!)
+    expect(screen.getByText(/Remove 2 selected/)).toBeInTheDocument()
+
+    // Deselect GitHub — count goes back to 1
+    await user.click(screen.getByText("GitHub").closest("button")!)
+    expect(screen.getByText(/Remove 1 selected/)).toBeInTheDocument()
+  })
+
+  it("bulk delete button is hidden when no credentials are selected", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar {...makeProps()} />)
+
+    rightClickCred("GitHub")
+    await user.click(screen.getByText("Remove multiple"))
+
+    // Deselect the pre-selected credential
+    await user.click(screen.getByText("GitHub").closest("button")!)
+
+    expect(screen.queryByText(/Remove \d+ selected/)).not.toBeInTheDocument()
+  })
+
+  it("bulk delete confirmation dialog lists selected credentials", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar {...makeProps()} />)
+
+    rightClickCred("GitHub")
+    await user.click(screen.getByText("Remove multiple"))
+    await user.click(screen.getByText(/Remove 1 selected/))
+
+    // Dialog title and the selected credential's label should be visible
+    expect(screen.getByText("Remove 1 credentials?")).toBeInTheDocument()
+    expect(screen.getAllByText("GitHub").length).toBeGreaterThan(0)
+  })
+
+  it("Remove all button is disabled until REMOVE is typed", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar {...makeProps()} />)
+
+    rightClickCred("GitHub")
+    await user.click(screen.getByText("Remove multiple"))
+    await user.click(screen.getByText(/Remove 1 selected/))
+
+    expect(screen.getByRole("button", { name: "Remove all" })).toBeDisabled()
+
+    await user.type(screen.getByPlaceholderText('Type "REMOVE" to confirm'), "REMOVE")
+
+    expect(screen.getByRole("button", { name: "Remove all" })).toBeEnabled()
+  })
+
+  it("confirming bulk delete calls onRemove for each selected credential", async () => {
+    const onRemove = vi.fn()
+    const user = userEvent.setup()
+    render(<Sidebar {...makeProps({ onRemove })} />)
+
+    rightClickCred("GitHub")
+    await user.click(screen.getByText("Remove multiple"))
+
+    // Select AWS as well
+    await user.click(screen.getByText("AWS").closest("button")!)
+    await user.click(screen.getByText(/Remove 2 selected/))
+
+    await user.type(screen.getByPlaceholderText('Type "REMOVE" to confirm'), "REMOVE")
+    await user.click(screen.getByRole("button", { name: "Remove all" }))
+
+    expect(onRemove).toHaveBeenCalledWith("cred-a")
+    expect(onRemove).toHaveBeenCalledWith("cred-b")
+    expect(onRemove).toHaveBeenCalledTimes(2)
+  })
+
+  it("Cancel in bulk delete dialog dismisses without calling onRemove", async () => {
+    const onRemove = vi.fn()
+    const user = userEvent.setup()
+    render(<Sidebar {...makeProps({ onRemove })} />)
+
+    rightClickCred("GitHub")
+    await user.click(screen.getByText("Remove multiple"))
+    await user.click(screen.getByText(/Remove 1 selected/))
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(onRemove).not.toHaveBeenCalled()
+    expect(screen.queryByText("Remove 1 credentials?")).not.toBeInTheDocument()
+  })
+})

--- a/cmd/tegata-gui/frontend/src/components/layout/Sidebar.test.tsx
+++ b/cmd/tegata-gui/frontend/src/components/layout/Sidebar.test.tsx
@@ -124,7 +124,7 @@ describe("Sidebar bulk deletion", () => {
     await user.click(screen.getByText(/Remove 1 selected/))
 
     // Dialog title and the selected credential's label should be visible
-    expect(screen.getByText("Remove 1 credentials?")).toBeInTheDocument()
+    expect(screen.getByText("Remove 1 credential?")).toBeInTheDocument()
     expect(screen.getAllByText("GitHub").length).toBeGreaterThan(0)
   })
 
@@ -174,6 +174,6 @@ describe("Sidebar bulk deletion", () => {
     await user.click(screen.getByRole("button", { name: "Cancel" }))
 
     expect(onRemove).not.toHaveBeenCalled()
-    expect(screen.queryByText("Remove 1 credentials?")).not.toBeInTheDocument()
+    expect(screen.queryByText("Remove 1 credential?")).not.toBeInTheDocument()
   })
 })

--- a/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
+++ b/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
@@ -337,9 +337,9 @@ export function Sidebar({
       <Dialog open={bulkDeleteConfirm} onOpenChange={(open) => { if (!open) { setBulkDeleteConfirm(false); setBulkDeleteInput("") } }}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Remove {selectedCreds.size} credentials?</DialogTitle>
+            <DialogTitle>Remove {selectedCreds.size} {selectedCreds.size === 1 ? "credential" : "credentials"}?</DialogTitle>
             <DialogDescription>
-              This action cannot be undone. Type <span className="font-mono font-semibold">REMOVE</span> to confirm removal of these {selectedCreds.size} credentials.
+              This action cannot be undone. Type <span className="font-mono font-semibold">REMOVE</span> to confirm removal of {selectedCreds.size === 1 ? "this credential" : `these ${selectedCreds.size} credentials`}.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">

--- a/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
+++ b/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
@@ -133,7 +133,7 @@ export function Sidebar({
                 setSelectedCreds(new Set())
               }}
             >
-              Done
+              Cancel
             </Button>
           )}
         </div>

--- a/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
+++ b/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Badge } from "@/components/ui/badge"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
 import type { Credential } from "@/lib/types"
 
@@ -63,6 +64,8 @@ export function Sidebar({
 }: SidebarProps) {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
   const [ctxMenu, setCtxMenu] = useState<ContextMenuState | null>(null)
+  const [deleteConfirmCred, setDeleteConfirmCred] = useState<Credential | null>(null)
+  const [deleteConfirmInput, setDeleteConfirmInput] = useState("")
   const menuRef = useRef<HTMLDivElement>(null)
 
   // Close context menu on outside click or Escape.
@@ -207,12 +210,63 @@ export function Sidebar({
           )}
           <button
             className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-accent"
-            onClick={() => { onRemove(ctxMenu.credential.id); setCtxMenu(null) }}
+            onClick={() => { setDeleteConfirmCred(ctxMenu.credential); setCtxMenu(null) }}
           >
             <Trash2 className="h-3.5 w-3.5" /> Remove
           </button>
         </div>
       )}
+
+      {/* Delete confirmation dialog for context menu */}
+      <Dialog open={!!deleteConfirmCred} onOpenChange={(open) => { if (!open) { setDeleteConfirmCred(null); setDeleteConfirmInput("") } }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove credential?</DialogTitle>
+            <DialogDescription>
+              This action cannot be undone. Type <span className="font-mono font-semibold">DELETE</span> to confirm removal of "{deleteConfirmCred?.label}".
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Input
+              placeholder='Type "DELETE" to confirm'
+              value={deleteConfirmInput}
+              onChange={(e) => setDeleteConfirmInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && deleteConfirmInput === "DELETE" && deleteConfirmCred) {
+                  onRemove(deleteConfirmCred.id)
+                  setDeleteConfirmCred(null)
+                  setDeleteConfirmInput("")
+                }
+              }}
+              autoFocus
+            />
+            <div className="flex gap-2">
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  if (deleteConfirmCred) {
+                    onRemove(deleteConfirmCred.id)
+                    setDeleteConfirmCred(null)
+                    setDeleteConfirmInput("")
+                  }
+                }}
+                disabled={deleteConfirmInput !== "DELETE"}
+              >
+                Remove
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setDeleteConfirmCred(null)
+                  setDeleteConfirmInput("")
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </aside>
   )
 }

--- a/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
+++ b/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
@@ -240,7 +240,7 @@ export function Sidebar({
             onClick={() => setBulkDeleteConfirm(true)}
           >
             <Trash2 className="mr-2 h-4 w-4" />
-            Delete {selectedCreds.size} selected
+            Remove {selectedCreds.size} selected
           </Button>
         </div>
       )}

--- a/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
+++ b/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { ChevronRight, Copy, Key, Plus, Search, Trash2, Check } from "lucide-react"
+import { ChevronRight, Copy, Key, Plus, Search, Trash2, Check, CheckCheck } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -277,7 +277,7 @@ export function Sidebar({
             className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-accent"
             onClick={() => { setSelectionMode(true); setSelectedCreds(new Set([ctxMenu.credential.id])); setCtxMenu(null) }}
           >
-            <Trash2 className="h-3.5 w-3.5" /> Remove multiple
+            <CheckCheck className="h-3.5 w-3.5" /> Remove multiple
           </button>
         </div>
       )}

--- a/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
+++ b/cmd/tegata-gui/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { ChevronRight, Copy, Key, Plus, Search, Trash2 } from "lucide-react"
+import { ChevronRight, Copy, Key, Plus, Search, Trash2, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -66,6 +66,10 @@ export function Sidebar({
   const [ctxMenu, setCtxMenu] = useState<ContextMenuState | null>(null)
   const [deleteConfirmCred, setDeleteConfirmCred] = useState<Credential | null>(null)
   const [deleteConfirmInput, setDeleteConfirmInput] = useState("")
+  const [selectionMode, setSelectionMode] = useState(false)
+  const [selectedCreds, setSelectedCreds] = useState<Set<string>>(new Set())
+  const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false)
+  const [bulkDeleteInput, setBulkDeleteInput] = useState("")
   const menuRef = useRef<HTMLDivElement>(null)
 
   // Close context menu on outside click or Escape.
@@ -119,6 +123,19 @@ export function Sidebar({
           <Button variant="outline" size="icon" className="h-8 w-8 shrink-0" onClick={onAddClick}>
             <Plus className="h-4 w-4" />
           </Button>
+          {selectionMode && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 px-2 text-xs shrink-0"
+              onClick={() => {
+                setSelectionMode(false)
+                setSelectedCreds(new Set())
+              }}
+            >
+              Done
+            </Button>
+          )}
         </div>
       </div>
 
@@ -143,34 +160,62 @@ export function Sidebar({
                 creds.map((cred) => (
                   <button
                     key={cred.id}
-                    onClick={() => onSelect(cred.id)}
+                    onClick={() => {
+                      if (selectionMode) {
+                        setSelectedCreds((prev) => {
+                          const next = new Set(prev)
+                          if (next.has(cred.id)) {
+                            next.delete(cred.id)
+                          } else {
+                            next.add(cred.id)
+                          }
+                          return next
+                        })
+                      } else {
+                        onSelect(cred.id)
+                      }
+                    }}
                     onContextMenu={(e) => {
+                      if (selectionMode) return
                       e.preventDefault()
                       e.stopPropagation()
                       setCtxMenu({ x: e.clientX, y: e.clientY, credential: cred })
                     }}
                     className={cn(
                       "flex w-full items-center justify-between rounded px-3 py-1.5 text-left text-sm hover:bg-accent",
-                      selectedId === cred.id && "bg-accent",
+                      selectedId === cred.id && !selectionMode && "bg-accent",
+                      selectedCreds.has(cred.id) && selectionMode && "bg-accent",
                     )}
                   >
-                    <div className="min-w-0">
-                      <div className="truncate font-medium">{cred.label}</div>
-                      {cred.issuer && (
-                        <div className="truncate text-xs text-muted-foreground">
-                          {cred.issuer}
+                    <div className="flex items-center gap-2 min-w-0">
+                      {selectionMode && (
+                        <div className={cn(
+                          "flex h-4 w-4 shrink-0 items-center justify-center rounded border border-input",
+                          selectedCreds.has(cred.id) && "bg-primary border-primary"
+                        )}>
+                          {selectedCreds.has(cred.id) && <Check className="h-3 w-3 text-primary-foreground" />}
                         </div>
                       )}
+                      <div className="min-w-0">
+                        <div className="truncate font-medium">{cred.label}</div>
+                        {cred.issuer && (
+                          <div className="truncate text-xs text-muted-foreground">
+                            {cred.issuer}
+                          </div>
+                        )}
+                      </div>
                     </div>
-                    <Badge
-                      variant="secondary"
-                      className={cn(
-                        "ml-2 shrink-0 text-[10px] uppercase",
-                        typeBadgeColor[cred.type],
-                      )}
-                    >
-                      {typeBadgeLabel[cred.type] ?? cred.type}
-                    </Badge>
+                    {!selectionMode && (
+                      <Badge
+                        variant="secondary"
+                        className={cn(
+                          "ml-2 shrink-0 text-[10px] uppercase",
+                          typeBadgeColor[cred.type],
+                        )}
+                      >
+                        {typeBadgeLabel[cred.type] ?? cred.type}
+                      </Badge>
+                    )}
                   </button>
                 ))}
             </div>
@@ -185,6 +230,20 @@ export function Sidebar({
           )}
         </div>
       </ScrollArea>
+
+      {selectionMode && selectedCreds.size > 0 && (
+        <div className="border-t border-border p-3">
+          <Button
+            variant="destructive"
+            size="sm"
+            className="w-full"
+            onClick={() => setBulkDeleteConfirm(true)}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            Delete {selectedCreds.size} selected
+          </Button>
+        </div>
+      )}
 
       {ctxMenu && (
         <div
@@ -214,6 +273,12 @@ export function Sidebar({
           >
             <Trash2 className="h-3.5 w-3.5" /> Remove
           </button>
+          <button
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-accent"
+            onClick={() => { setSelectionMode(true); setSelectedCreds(new Set([ctxMenu.credential.id])); setCtxMenu(null) }}
+          >
+            <Trash2 className="h-3.5 w-3.5" /> Remove multiple
+          </button>
         </div>
       )}
 
@@ -223,16 +288,16 @@ export function Sidebar({
           <DialogHeader>
             <DialogTitle>Remove credential?</DialogTitle>
             <DialogDescription>
-              This action cannot be undone. Type <span className="font-mono font-semibold">DELETE</span> to confirm removal of "{deleteConfirmCred?.label}".
+              This action cannot be undone. Type <span className="font-mono font-semibold">REMOVE</span> to confirm removal of "{deleteConfirmCred?.label}".
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <Input
-              placeholder='Type "DELETE" to confirm'
+              placeholder='Type "REMOVE" to confirm'
               value={deleteConfirmInput}
               onChange={(e) => setDeleteConfirmInput(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && deleteConfirmInput === "DELETE" && deleteConfirmCred) {
+                if (e.key === "Enter" && deleteConfirmInput === "REMOVE" && deleteConfirmCred) {
                   onRemove(deleteConfirmCred.id)
                   setDeleteConfirmCred(null)
                   setDeleteConfirmInput("")
@@ -250,7 +315,7 @@ export function Sidebar({
                     setDeleteConfirmInput("")
                   }
                 }}
-                disabled={deleteConfirmInput !== "DELETE"}
+                disabled={deleteConfirmInput !== "REMOVE"}
               >
                 Remove
               </Button>
@@ -259,6 +324,69 @@ export function Sidebar({
                 onClick={() => {
                   setDeleteConfirmCred(null)
                   setDeleteConfirmInput("")
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Bulk delete confirmation dialog */}
+      <Dialog open={bulkDeleteConfirm} onOpenChange={(open) => { if (!open) { setBulkDeleteConfirm(false); setBulkDeleteInput("") } }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove {selectedCreds.size} credentials?</DialogTitle>
+            <DialogDescription>
+              This action cannot be undone. Type <span className="font-mono font-semibold">REMOVE</span> to confirm removal of these {selectedCreds.size} credentials.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="max-h-48 overflow-y-auto rounded border border-border bg-muted/50 p-3">
+              <ul className="space-y-2 text-sm">
+                {filtered.map((cred) => selectedCreds.has(cred.id) && (
+                  <li key={cred.id} className="text-muted-foreground">
+                    <span className="font-medium">{cred.label}</span>
+                    {cred.issuer && <span className="text-xs"> — {cred.issuer}</span>}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <Input
+              placeholder='Type "REMOVE" to confirm'
+              value={bulkDeleteInput}
+              onChange={(e) => setBulkDeleteInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && bulkDeleteInput === "REMOVE") {
+                  selectedCreds.forEach(id => onRemove(id))
+                  setBulkDeleteConfirm(false)
+                  setBulkDeleteInput("")
+                  setSelectedCreds(new Set())
+                  setSelectionMode(false)
+                }
+              }}
+              autoFocus
+            />
+            <div className="flex gap-2">
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  selectedCreds.forEach(id => onRemove(id))
+                  setBulkDeleteConfirm(false)
+                  setBulkDeleteInput("")
+                  setSelectedCreds(new Set())
+                  setSelectionMode(false)
+                }}
+                disabled={bulkDeleteInput !== "REMOVE"}
+              >
+                Remove all
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setBulkDeleteConfirm(false)
+                  setBulkDeleteInput("")
                 }}
               >
                 Cancel

--- a/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
+++ b/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
@@ -411,35 +411,44 @@ function ExportImport({ onImported }: { onImported: () => void }) {
 
       {showExport && (
         <div className="space-y-2 rounded-md border border-border p-3">
-          <p className="text-xs text-muted-foreground">
-            Enter a passphrase to encrypt the export file.
-          </p>
-          <Input
-            type="password"
-            placeholder="Export passphrase"
-            value={exportPass}
-            onChange={(e) => { setExportPass(e.target.value); setMessage(null) }}
-          />
-          {exportPass.length > 0 && <StrengthMeter passphrase={exportPass} />}
-          <Input
-            type="password"
-            placeholder="Confirm passphrase"
-            value={exportConfirm}
-            onChange={(e) => { setExportConfirm(e.target.value); setMessage(null) }}
-          />
-          {message && (
-            <p className={`text-sm ${message.error ? "text-destructive" : "text-green-500"}`}>
-              {message.text}
-            </p>
+          {message && !message.error ? (
+            <>
+              <p className="text-sm text-green-500">{message.text}</p>
+              <Button size="sm" variant="outline" onClick={() => { setShowExport(false); setExportPass(""); setExportConfirm(""); setMessage(null) }}>
+                Done
+              </Button>
+            </>
+          ) : (
+            <>
+              <p className="text-xs text-muted-foreground">
+                Enter a passphrase to encrypt the export file.
+              </p>
+              <Input
+                type="password"
+                placeholder="Export passphrase"
+                value={exportPass}
+                onChange={(e) => { setExportPass(e.target.value); setMessage(null) }}
+              />
+              {exportPass.length > 0 && <StrengthMeter passphrase={exportPass} />}
+              <Input
+                type="password"
+                placeholder="Confirm passphrase"
+                value={exportConfirm}
+                onChange={(e) => { setExportConfirm(e.target.value); setMessage(null) }}
+              />
+              {message && (
+                <p className="text-sm text-destructive">{message.text}</p>
+              )}
+              <div className="flex gap-2">
+                <Button size="sm" onClick={handleExport} disabled={!exportPass || !exportConfirm || loading}>
+                  {loading ? "Exporting..." : "Export to file"}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => { setShowExport(false); setExportPass(""); setExportConfirm(""); setMessage(null) }} disabled={loading}>
+                  Cancel
+                </Button>
+              </div>
+            </>
           )}
-          <div className="flex gap-2">
-            <Button size="sm" onClick={handleExport} disabled={!exportPass || !exportConfirm || loading}>
-              {loading ? "Exporting..." : "Export to file"}
-            </Button>
-            <Button size="sm" variant="outline" onClick={() => { setShowExport(false); setExportPass(""); setExportConfirm(""); setMessage(null) }}>
-              Cancel
-            </Button>
-          </div>
         </div>
       )}
 

--- a/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
+++ b/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
@@ -115,13 +115,14 @@ export function SettingsPanel({ open, onClose, onCredentialsChanged, updateInfo 
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-lg bg-card p-6 shadow-lg max-h-[80vh] overflow-y-auto">
-        <div className="mb-4 flex items-center justify-between">
+      <div className="w-full max-w-md rounded-lg bg-card shadow-lg flex flex-col max-h-[80vh]">
+        <div className="flex items-center justify-between border-b p-3">
           <h2 className="text-lg font-semibold">Settings</h2>
           <Button variant="ghost" size="icon" className="h-8 w-8" onClick={onClose}>
             <X className="h-4 w-4" />
           </Button>
         </div>
+        <div className="overflow-y-auto p-6">
 
         {/* Theme */}
         <section className="space-y-2">
@@ -325,6 +326,7 @@ export function SettingsPanel({ open, onClose, onCredentialsChanged, updateInfo 
           {appVersion && <p className="text-xs text-muted-foreground">Version: {appVersion}</p>}
           <p className="text-xs text-muted-foreground">License: MIT</p>
         </section>
+        </div>
       </div>
     </div>
   )

--- a/cmd/tegata-gui/frontend/src/lib/types.ts
+++ b/cmd/tegata-gui/frontend/src/lib/types.ts
@@ -44,5 +44,6 @@ export interface AuditHistoryRecord {
 export interface AuditVerifyResult {
   valid: boolean
   event_count: number
-  error_detail?: string
+  skipped?: number
+  faults?: string[]
 }

--- a/cmd/tegata-gui/frontend/src/lib/wails.ts
+++ b/cmd/tegata-gui/frontend/src/lib/wails.ts
@@ -40,6 +40,7 @@ interface WailsAppBindings {
   AddCredentialFromURI(uri: string): Promise<string>
   RemoveCredential(id: string): Promise<void>
   GenerateTOTP(label: string): Promise<TOTPResult>
+  RecordTOTPUsed(label: string): Promise<void>
   GenerateHOTP(label: string): Promise<string>
   GetStaticPassword(label: string): Promise<void>
   SignChallenge(label: string, challenge: string): Promise<string>
@@ -89,6 +90,7 @@ export const App = {
   AddCredentialFromURI: (uri: string) => getApp().AddCredentialFromURI(uri),
   RemoveCredential: (id: string) => getApp().RemoveCredential(id),
   GenerateTOTP: (label: string) => getApp().GenerateTOTP(label),
+  RecordTOTPUsed: (label: string) => getApp().RecordTOTPUsed(label),
   GenerateHOTP: (label: string) => getApp().GenerateHOTP(label),
   GetStaticPassword: (label: string) => getApp().GetStaticPassword(label),
   SignChallenge: (label: string, challenge: string) => getApp().SignChallenge(label, challenge),

--- a/cmd/tegata/code.go
+++ b/cmd/tegata/code.go
@@ -55,6 +55,11 @@ func newCodeCmd() *cobra.Command {
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
+				builder.OnHashStored = func(eventID, hashValue string) {
+					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+					}
+				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/get.go
+++ b/cmd/tegata/get.go
@@ -47,6 +47,11 @@ func newGetCmd() *cobra.Command {
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
+				builder.OnHashStored = func(eventID, hashValue string) {
+					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+					}
+				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/ledger_test.go
+++ b/cmd/tegata/ledger_test.go
@@ -25,7 +25,7 @@ func (m *mockAuditClient) Get(_ context.Context, _ string) ([]*audit.EventRecord
 	return nil, nil
 }
 
-func (m *mockAuditClient) Validate(_ context.Context, _ string) (*audit.ValidationResult, error) {
+func (m *mockAuditClient) Validate(_ context.Context, _, _ string) (*audit.ValidationResult, error) {
 	return nil, nil
 }
 
@@ -41,8 +41,8 @@ func (m *mockAuditClient) Close() error {
 	return nil
 }
 
-func (m *mockAuditClient) Submit(_ context.Context, _ audit.QueueEntry) error {
-	return nil
+func (m *mockAuditClient) Submit(_ context.Context, _ audit.QueueEntry) (string, error) {
+	return "", nil
 }
 
 func (m *mockAuditClient) PutWithMetadata(_ context.Context, _, _ string, _ map[string]interface{}) error {

--- a/cmd/tegata/main.go
+++ b/cmd/tegata/main.go
@@ -13,9 +13,19 @@ import (
 // version is set via -ldflags "-X main.version=..." at build time.
 var version = "dev"
 
+// reportedError wraps an error that has already been printed to the user.
+// main() skips printing for these so commands can control their own output order.
+type reportedError struct{ err error }
+
+func (e reportedError) Error() string { return e.err.Error() }
+func (e reportedError) Unwrap() error { return e.err }
+
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		var re reportedError
+		if !errors.As(err, &re) {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		}
 		os.Exit(errors.ExitCode(err))
 	}
 }

--- a/cmd/tegata/sign.go
+++ b/cmd/tegata/sign.go
@@ -56,6 +56,11 @@ func newSignCmd() *cobra.Command {
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
+				builder.OnHashStored = func(eventID, hashValue string) {
+					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+					}
+				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/tui_main.go
+++ b/cmd/tegata/tui_main.go
@@ -362,7 +362,7 @@ func (m model) renderDetailPanel(width int) string {
 	}
 
 	if m.statusMsg != "" {
-		content += "\n\n" + successStyle.Render(m.statusMsg)
+		content += "\n\n" + tipStyle.Render(m.statusMsg)
 	}
 	if m.errMsg != "" {
 		content += "\n\n" + errorStyle.Render(m.errMsg)

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -336,7 +337,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else if msg.valid {
 			m.auditMsg = fmt.Sprintf("Audit log integrity verified. %d events checked.", msg.eventCount)
 		} else {
-			m.auditMsg = fmt.Sprintf("TAMPER DETECTED: %s", msg.detail)
+			var sb strings.Builder
+			sb.WriteString("TAMPERING DETECTED\n")
+			for _, f := range msg.faults {
+				sb.WriteString(formatFault(f) + "\n")
+			}
+			m.auditMsg = strings.TrimRight(sb.String(), "\n")
 		}
 		return m, nil
 

--- a/cmd/tegata/tui_model_test.go
+++ b/cmd/tegata/tui_model_test.go
@@ -561,11 +561,11 @@ func TestTUI_AuditVerifyValid(t *testing.T) {
 
 func TestTUI_AuditTamperDetected(t *testing.T) {
 	m := model{state: stateOverlayAudit, auditSubFlow: "verify", auditLoading: true}
-	msg := auditVerifyMsg{valid: false, eventCount: 3, detail: "hash mismatch at version 2"}
+	msg := auditVerifyMsg{valid: false, eventCount: 3, faults: []string{"tegata-abc123: record hash has been altered"}}
 	updated, _ := m.Update(msg)
 	result := updated.(model)
-	if !strings.Contains(result.auditMsg, "TAMPER DETECTED") {
-		t.Errorf("expected 'TAMPER DETECTED' in msg, got %q", result.auditMsg)
+	if !strings.Contains(result.auditMsg, "TAMPERING DETECTED") {
+		t.Errorf("expected 'TAMPERING DETECTED' in msg, got %q", result.auditMsg)
 	}
 }
 

--- a/cmd/tegata/tui_overlay_add.go
+++ b/cmd/tegata/tui_overlay_add.go
@@ -403,9 +403,9 @@ func renderAddSelector(label string, slot, focusIdx, selectedIdx int, options []
 	for i, opt := range options {
 		if i == selectedIdx {
 			if focused {
-				parts = append(parts, successStyle.Render("\u2190 "+opt+" \u2192"))
+				parts = append(parts, tipStyle.Render("\u2190 "+opt+" \u2192"))
 			} else {
-				parts = append(parts, successStyle.Render(opt))
+				parts = append(parts, tipStyle.Render(opt))
 			}
 		} else {
 			parts = append(parts, opt)

--- a/cmd/tegata/tui_overlay_audit.go
+++ b/cmd/tegata/tui_overlay_audit.go
@@ -28,7 +28,7 @@ type auditVerifyMsg struct {
 	valid      bool
 	eventCount int
 	skipped    int
-	detail     string
+	faults     []string // per-event fault descriptions when !valid
 	err        error
 }
 
@@ -96,7 +96,7 @@ func auditVerifyCmd(cfg config.AuditConfig, vaultHashes map[string]string) tea.C
 			valid:      result.Valid,
 			eventCount: result.EventCount,
 			skipped:    result.Skipped,
-			detail:     result.ErrorDetail,
+			faults:     result.Faults,
 		}
 	}
 }
@@ -262,7 +262,7 @@ func (m model) viewAuditVerify() string {
 	}
 
 	var body string
-	if strings.Contains(m.auditMsg, "TAMPER DETECTED") {
+	if strings.Contains(m.auditMsg, "TAMPERING DETECTED") {
 		body = errorStyle.Render(m.auditMsg)
 	} else if strings.Contains(m.auditMsg, "verified") {
 		body = tipStyle.Render(m.auditMsg)

--- a/cmd/tegata/tui_overlay_audit.go
+++ b/cmd/tegata/tui_overlay_audit.go
@@ -204,7 +204,7 @@ func (m model) viewAuditMenu() string {
 	var menu strings.Builder
 	for i, item := range items {
 		if i == m.auditMenuIdx {
-			menu.WriteString(successStyle.Render("▸ " + item))
+			menu.WriteString(tipStyle.Render("▸ " + item))
 		} else {
 			menu.WriteString("  " + item)
 		}
@@ -265,7 +265,7 @@ func (m model) viewAuditVerify() string {
 	if strings.Contains(m.auditMsg, "TAMPER DETECTED") {
 		body = errorStyle.Render(m.auditMsg)
 	} else if strings.Contains(m.auditMsg, "verified") {
-		body = successStyle.Render(m.auditMsg)
+		body = tipStyle.Render(m.auditMsg)
 	} else {
 		body = m.auditMsg
 	}
@@ -327,7 +327,7 @@ func (m model) viewAuditStart() string {
 			strings.Contains(m.auditMsg, "error") || strings.Contains(m.auditMsg, "Error") {
 			body = errorStyle.Render(m.auditMsg)
 		} else {
-			body = successStyle.Render(m.auditMsg)
+			body = tipStyle.Render(m.auditMsg)
 		}
 	}
 

--- a/cmd/tegata/tui_overlay_audit.go
+++ b/cmd/tegata/tui_overlay_audit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/config"
+	"github.com/josh-wong/tegata/internal/vault"
 )
 
 // auditHistoryMsg carries the result of an async history fetch.
@@ -26,6 +27,7 @@ type auditHistoryMsg struct {
 type auditVerifyMsg struct {
 	valid      bool
 	eventCount int
+	skipped    int
 	detail     string
 	err        error
 }
@@ -71,8 +73,12 @@ func auditHistoryCmd(cfg config.AuditConfig) tea.Cmd {
 }
 
 // auditVerifyCmd creates a tea.Cmd that runs audit verification asynchronously.
-func auditVerifyCmd(cfg config.AuditConfig) tea.Cmd {
+// vaultHashes is the caller's copy of the audit hash map from the vault; the
+// cmd takes ownership and zeros it after use (D-16).
+func auditVerifyCmd(cfg config.AuditConfig, vaultHashes map[string]string) tea.Cmd {
 	return func() tea.Msg {
+		defer vault.ZeroAuditHashes(vaultHashes)
+
 		client, err := audit.NewClientFromConfig(cfg)
 		if err != nil {
 			return auditVerifyMsg{err: err}
@@ -82,13 +88,14 @@ func auditVerifyCmd(cfg config.AuditConfig) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		result, err := audit.VerifyAll(ctx, client, cfg.EntityID)
+		result, err := audit.VerifyAll(ctx, client, cfg.EntityID, vaultHashes)
 		if err != nil {
 			return auditVerifyMsg{err: err}
 		}
 		return auditVerifyMsg{
 			valid:      result.Valid,
 			eventCount: result.EventCount,
+			skipped:    result.Skipped,
 			detail:     result.ErrorDetail,
 		}
 	}
@@ -160,7 +167,11 @@ func (m model) updateOverlayAudit(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case 1:
 				m.auditSubFlow = "verify"
 				m.auditLoading = true
-				return m, auditVerifyCmd(m.cfg.Audit)
+				var hashes map[string]string
+				if m.vaultMgr != nil {
+					hashes = m.vaultMgr.AuditHashes()
+				}
+				return m, auditVerifyCmd(m.cfg.Audit, hashes)
 			}
 		}
 	}

--- a/cmd/tegata/tui_overlay_settings.go
+++ b/cmd/tegata/tui_overlay_settings.go
@@ -651,14 +651,14 @@ func (m model) viewSettingsMenu() string {
 	lines = append(lines, "")
 	for i, item := range settingsMenuItems {
 		if i == m.settingsMenuIdx {
-			lines = append(lines, successStyle.Render("> "+item))
+			lines = append(lines, tipStyle.Render("> "+item))
 		} else {
 			lines = append(lines, "  "+item)
 		}
 	}
 	if m.settingsMsg != "" {
 		lines = append(lines, "")
-		lines = append(lines, successStyle.Render(m.settingsMsg))
+		lines = append(lines, tipStyle.Render(m.settingsMsg))
 	}
 	lines = append(lines, "")
 	lines = append(lines, helpBarStyle.Render("[↑↓] Navigate  [Enter] Select  [Esc] Close"))
@@ -683,7 +683,7 @@ func (m model) viewSettingsTags() string {
 	} else {
 		for i, tag := range tags {
 			if i == m.settingsTagIdx {
-				lines = append(lines, successStyle.Render("> "+tag))
+				lines = append(lines, tipStyle.Render("> "+tag))
 			} else {
 				lines = append(lines, "  "+tag)
 			}
@@ -697,7 +697,7 @@ func (m model) viewSettingsTags() string {
 
 	if m.settingsMsg != "" {
 		lines = append(lines, "")
-		lines = append(lines, successStyle.Render(m.settingsMsg))
+		lines = append(lines, tipStyle.Render(m.settingsMsg))
 	}
 	lines = append(lines, "")
 	lines = append(lines, helpBarStyle.Render("[a] Add  [d] Remove  [Esc] Done"))
@@ -765,7 +765,7 @@ func (m model) viewSettingsExportImport(title, label1, label2, help string) stri
 	lines = append(lines, label2+": "+m.settingsInput2.View())
 	if m.settingsMsg != "" {
 		lines = append(lines, "")
-		lines = append(lines, successStyle.Render(m.settingsMsg))
+		lines = append(lines, tipStyle.Render(m.settingsMsg))
 	}
 	lines = append(lines, "")
 	lines = append(lines, helpBarStyle.Render(help))
@@ -831,7 +831,7 @@ func (m model) viewSettingsRecovery() string {
 	if m.settingsMsg != "" {
 		lines = append(lines, "")
 		if strings.Contains(m.settingsMsg, "valid") && !strings.Contains(m.settingsMsg, "invalid") {
-			lines = append(lines, successStyle.Render(m.settingsMsg))
+			lines = append(lines, tipStyle.Render(m.settingsMsg))
 		} else {
 			lines = append(lines, errorStyle.Render(m.settingsMsg))
 		}
@@ -863,7 +863,7 @@ func (m model) viewSettingsConfig() string {
 	}
 	if m.settingsMsg != "" {
 		lines = append(lines, "")
-		lines = append(lines, successStyle.Render(m.settingsMsg))
+		lines = append(lines, tipStyle.Render(m.settingsMsg))
 	}
 	lines = append(lines, "")
 	helpText := "[c] Edit clipboard  [i] Edit idle  [Esc] Back"

--- a/cmd/tegata/tui_styles.go
+++ b/cmd/tegata/tui_styles.go
@@ -8,9 +8,6 @@ var titleStyle = lipgloss.NewStyle().Bold(true).AlignHorizontal(lipgloss.Center)
 // errorStyle renders error messages in red.
 var errorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF5F5F"))
 
-// successStyle renders success or info messages in green.
-var successStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#5FFF5F"))
-
 // helpBarStyle renders the bottom help bar in dim/faint text.
 var helpBarStyle = lipgloss.NewStyle().Faint(true)
 

--- a/cmd/tegata/tui_unlock.go
+++ b/cmd/tegata/tui_unlock.go
@@ -98,6 +98,17 @@ func (m model) handleUnlockResult(msg unlockResultMsg) (tea.Model, tea.Cmd) {
 		m.vaultID = msg.mgr.VaultID()
 	}
 	m.builder = msg.builder
+
+	// Wire OnHashStored so submitted audit event hashes are persisted to the
+	// vault for independent verification (D-15).
+	if m.builder != nil && m.vaultMgr != nil {
+		mgr := m.vaultMgr
+		m.builder.OnHashStored = func(eventID, hashValue string) {
+			if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "tegata: failed to store audit hash: %v\n", err)
+			}
+		}
+	}
 	m.passphraseInput.Blur()
 	m = loadCredentials(m)
 	m.state = stateMainView

--- a/cmd/tegata/tui_wizard.go
+++ b/cmd/tegata/tui_wizard.go
@@ -477,7 +477,7 @@ func strengthLabel(pass []byte) string {
 	_, label := strengthLevel(pass)
 	switch label {
 	case "Strong":
-		return successStyle.Render(label)
+		return tipStyle.Render(label)
 	case "Weak", "Too short":
 		return errorStyle.Render(label)
 	default:

--- a/cmd/tegata/verify.go
+++ b/cmd/tegata/verify.go
@@ -9,6 +9,7 @@ import (
 	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/config"
 	tegerrors "github.com/josh-wong/tegata/internal/errors"
+	"github.com/josh-wong/tegata/internal/vault"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +47,20 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
+	passphrase, err := promptPassphrase("Passphrase: ")
+	if err != nil {
+		return err
+	}
+	mgr, err := openAndUnlock(vaultPath, passphrase)
+	zeroBytes(passphrase)
+	if err != nil {
+		return err
+	}
+	defer mgr.Close()
+
+	hashes := mgr.AuditHashes()
+	defer vault.ZeroAuditHashes(hashes)
+
 	client, err := audit.NewClientFromConfig(cfg.Audit)
 	if err != nil {
 		return fmt.Errorf("%w: connecting to ledger: %s", tegerrors.ErrNetworkFailed, err)
@@ -55,18 +70,26 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	result, err := audit.VerifyAll(ctx, client, cfg.Audit.EntityID)
+	result, err := audit.VerifyAll(ctx, client, cfg.Audit.EntityID, hashes)
 	if err != nil {
 		return err
 	}
 
-	if result.EventCount == 0 {
+	if result.EventCount == 0 && result.Skipped == 0 {
 		_, _ = fmt.Fprintln(os.Stdout, "No audit events found. Nothing to verify.")
 		return nil
 	}
 
+	if result.Skipped > 0 {
+		fmt.Fprintf(os.Stderr, "Note: %d events pre-date independent hash storage and were not verified.\n", result.Skipped)
+	}
+
 	if result.Valid {
-		fmt.Printf("Audit log integrity verified. %d events checked.\n", result.EventCount)
+		if result.EventCount > 0 {
+			fmt.Printf("Audit log integrity verified. %d events checked.\n", result.EventCount)
+		} else {
+			fmt.Printf("No events could be verified — all %d events pre-date independent hash storage.\n", result.Skipped)
+		}
 		return nil
 	}
 

--- a/cmd/tegata/verify.go
+++ b/cmd/tegata/verify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/josh-wong/tegata/internal/audit"
@@ -29,6 +30,21 @@ Requires audit to be enabled in tegata.toml ([audit] enabled = true).`,
 		Args: cobra.NoArgs,
 		RunE: runVerify,
 	}
+}
+
+// formatFault converts an "id: detail" fault string into a readable sentence.
+// Normal faults become "The {detail} for record {id}".
+// Error faults (from Validate returning an error) become "Verification error for record {id}: {err}".
+func formatFault(f string) string {
+	idx := strings.Index(f, ": ")
+	if idx < 0 {
+		return f
+	}
+	id, detail := f[:idx], f[idx+2:]
+	if strings.HasPrefix(detail, "error: ") {
+		return fmt.Sprintf("Verification error for record %s: %s", id, strings.TrimPrefix(detail, "error: "))
+	}
+	return fmt.Sprintf("The %s for record %s", detail, id)
 }
 
 func runVerify(cmd *cobra.Command, _ []string) error {
@@ -93,9 +109,9 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	fmt.Fprintf(os.Stderr, "Integrity violation detected in %d of %d events:\n", len(result.Faults), result.EventCount)
+	fmt.Fprintf(os.Stderr, "TAMPERING DETECTED\n")
 	for _, f := range result.Faults {
-		fmt.Fprintf(os.Stderr, "  %s\n", f)
+		fmt.Fprintf(os.Stderr, "  %s\n", formatFault(f))
 	}
-	return tegerrors.ErrIntegrityViolation
+	return reportedError{tegerrors.ErrIntegrityViolation}
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -409,14 +409,17 @@ tegata ui
 
 ### tegata verify
 
-Verify the integrity of the audit log stored in ScalarDL Ledger. Retrieves all event IDs from the entity's collection and validates each event individually. Reports the total number of events checked and lists per-event faults if any are detected.
+Verify the integrity of the audit log stored in ScalarDL Ledger. Unlocks the vault (requires passphrase) to read audit event hashes stored during credential operations. Retrieves all event IDs from the entity's collection and validates each event individually against its stored hash. Reports the total number of events verified and lists per-event faults if any are detected.
 
-**Usage:** `tegata verify`
+Events logged before audit hashes were stored independently are reported as pre-existing and skipped (they cannot be verified without a hash).
+
+**Usage:** `tegata verify [--vault <path>]`
 
 **Example:**
 
 ```bash
 tegata verify
+tegata verify --vault /media/usb/vault.tegata
 ```
 
 Exit codes: 0 on success, 9 on integrity violation, 8 on network failure. Requires audit to be enabled in `tegata.toml`.

--- a/internal/audit/builder.go
+++ b/internal/audit/builder.go
@@ -23,13 +23,14 @@ import (
 // Auth commands are never blocked or returned errors due to audit failures
 // — audit errors are silently absorbed, keeping the event in the queue.
 type EventBuilder struct {
-	client     Submitter      // nil when audit is disabled
-	queue      *Queue
-	queuePath  string
-	queueKey   []byte         // 32-byte key; EventBuilder does NOT own lifecycle
-	disabled   bool           // true when client == nil
-	lastHash   string         // SHA-256 of the last successfully submitted event JSON
-	submitTimeout time.Duration // timeout for submit operations (default 3s)
+	client        Submitter      // nil when audit is disabled
+	queue         *Queue
+	queuePath     string
+	queueKey      []byte         // 32-byte key; EventBuilder does NOT own lifecycle
+	disabled      bool           // true when client == nil
+	lastHash      string         // SHA-256 of the last successfully submitted event JSON
+	submitTimeout time.Duration  // timeout for submit operations (default 3s)
+	OnHashStored  func(eventID, hashValue string) // called after successful Submit to store hash in vault (D-15)
 }
 
 // NewEventBuilder creates an EventBuilder. If client is nil the builder is
@@ -132,20 +133,36 @@ func (b *EventBuilder) LogEvent(opType, label, service, host string, success boo
 
 	go func() {
 		// Submit any previously queued events from the snapshot.
+		// For queued events, capture (string, error) but only use the error;
+		// their hashes were either already stored or missed.
 		for _, e := range snapshot {
-			if err := b.client.Submit(ctx, e); err != nil {
+			if _, err := b.client.Submit(ctx, e); err != nil {
 				resultCh <- submitResult{err: err}
 				return
 			}
 		}
 
 		entry := QueueEntry{Event: evt}
-		if err := b.client.Submit(ctx, entry); err != nil {
+		hashValue, err := b.client.Submit(ctx, entry)
+		if err != nil {
 			resultCh <- submitResult{err: err}
 			return
 		}
 
-		// Success: compute the hash of the newly submitted event.
+		// Call OnHashStored callback for the new event (not queued events).
+		// Best-effort: log and swallow errors (per D-14).
+		if b.OnHashStored != nil {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("audit OnHashStored panic", "err", r)
+					}
+				}()
+				b.OnHashStored(entry.Event.EventID, hashValue)
+			}()
+		}
+
+		// Success: compute the hash of the newly submitted event for chain.
 		// AuthEvent contains only string, bool, and time.Time fields, so
 		// Marshal failure is a programming error — panic like EntryHash does.
 		eventJSON, err := json.Marshal(evt)

--- a/internal/audit/builder.go
+++ b/internal/audit/builder.go
@@ -132,13 +132,24 @@ func (b *EventBuilder) LogEvent(opType, label, service, host string, success boo
 	resultCh := make(chan submitResult, 1)
 
 	go func() {
-		// Submit any previously queued events from the snapshot.
-		// For queued events, capture (string, error) but only use the error;
-		// their hashes were either already stored or missed.
+		// Submit any previously queued events from the snapshot and store
+		// their hashes via OnHashStored — queued events failed to submit
+		// originally so their hashes were never persisted (D-15).
 		for _, e := range snapshot {
-			if _, err := b.client.Submit(ctx, e); err != nil {
+			hashValue, err := b.client.Submit(ctx, e)
+			if err != nil {
 				resultCh <- submitResult{err: err}
 				return
+			}
+			if b.OnHashStored != nil && hashValue != "" {
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							slog.Error("audit OnHashStored panic (queued event)", "err", r)
+						}
+					}()
+					b.OnHashStored(e.Event.EventID, hashValue)
+				}()
 			}
 		}
 

--- a/internal/audit/builder.go
+++ b/internal/audit/builder.go
@@ -33,6 +33,17 @@ type EventBuilder struct {
 	OnHashStored  func(eventID, hashValue string) // called after successful Submit to store hash in vault (D-15)
 }
 
+// callSafe invokes fn, recovering any panic and logging it. Used for best-effort
+// callbacks that must not crash the caller (D-14).
+func callSafe(fn func(), panicMsg string) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error(panicMsg, "err", r)
+		}
+	}()
+	fn()
+}
+
 // NewEventBuilder creates an EventBuilder. If client is nil the builder is
 // disabled and LogEvent becomes a no-op. When client is non-nil, the offline
 // queue is loaded from queuePath (creating an empty queue if the file does not
@@ -142,14 +153,8 @@ func (b *EventBuilder) LogEvent(opType, label, service, host string, success boo
 				return
 			}
 			if b.OnHashStored != nil && hashValue != "" {
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							slog.Error("audit OnHashStored panic (queued event)", "err", r)
-						}
-					}()
-					b.OnHashStored(e.Event.EventID, hashValue)
-				}()
+				id, hv := e.Event.EventID, hashValue
+				callSafe(func() { b.OnHashStored(id, hv) }, "audit OnHashStored panic (queued event)")
 			}
 		}
 
@@ -160,17 +165,10 @@ func (b *EventBuilder) LogEvent(opType, label, service, host string, success boo
 			return
 		}
 
-		// Call OnHashStored callback for the new event (not queued events).
-		// Best-effort: log and swallow errors (per D-14).
+		// Call OnHashStored callback for the new event. Best-effort (D-14).
 		if b.OnHashStored != nil {
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						slog.Error("audit OnHashStored panic", "err", r)
-					}
-				}()
-				b.OnHashStored(entry.Event.EventID, hashValue)
-			}()
+			id, hv := entry.Event.EventID, hashValue
+			callSafe(func() { b.OnHashStored(id, hv) }, "audit OnHashStored panic")
 		}
 
 		// Success: compute the hash of the newly submitted event for chain.

--- a/internal/audit/builder_test.go
+++ b/internal/audit/builder_test.go
@@ -19,17 +19,17 @@ type mockSubmitter struct {
 	delay   time.Duration // if non-zero, Sleep before returning
 }
 
-func (m *mockSubmitter) Submit(_ context.Context, entry QueueEntry) error {
+func (m *mockSubmitter) Submit(_ context.Context, entry QueueEntry) (string, error) {
 	if m.delay > 0 {
 		time.Sleep(m.delay)
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.failErr != nil {
-		return m.failErr
+		return "", m.failErr
 	}
 	m.calls = append(m.calls, entry)
-	return nil
+	return "fakehash", nil
 }
 
 func (m *mockSubmitter) CallCount() int {

--- a/internal/audit/client.go
+++ b/internal/audit/client.go
@@ -544,6 +544,15 @@ func (c *LedgerClient) Validate(ctx context.Context, objectID, expectedHash stri
 	}
 	// Each event uses a UUID EventID written exactly once, so len > 1 is
 	// unexpected and is itself evidence of tampering or a replay.
+	//
+	// NOTE: With the current ScalarDL HashStore SDK (v3.13+), this branch is
+	// unreachable in practice. The object.v1_0_0.Get contract is implemented in
+	// generic-contracts and calls ledger.get(), which returns Optional<Asset> —
+	// at most one record. The HashStore bootstrap registers the same generic
+	// contract class directly (hash-store depends on generic-contracts; it ships
+	// no separate Get implementation). If ScalarDL ever exposes a contract that
+	// returns multiple versions (e.g. via ledger.scan()), this guard would
+	// become active. Keep it for defensive correctness and to signal intent.
 	if len(records) > 1 {
 		return &ValidationResult{
 			Valid:       false,

--- a/internal/audit/client.go
+++ b/internal/audit/client.go
@@ -41,7 +41,12 @@ type Client interface {
 	// Get retrieves all event records for objectID from the ledger.
 	Get(ctx context.Context, objectID string) ([]*EventRecord, error)
 	// Validate verifies the integrity of objectID against the caller-supplied
-	// expectedHash. The hash comes from the vault, not from ScalarDL.
+	// expectedHash from the vault. It fetches the stored record via Get and
+	// performs three local checks: (1) stored hash_value == expectedHash, and
+	// (2) SHA-256(stored content) == expectedHash when content is present,
+	// and (3) individual metadata display fields (operation, label_hash) match
+	// the authenticated content. Check (3) detects targeted tampering of
+	// individual fields when hash_value and content are left intact.
 	Validate(ctx context.Context, objectID, expectedHash string) (*ValidationResult, error)
 	// CollectionCreate creates a new collection with the given object IDs.
 	CollectionCreate(ctx context.Context, collectionID string, objectIDs []string) error
@@ -512,67 +517,75 @@ func (c *LedgerClient) Get(ctx context.Context, objectID string) ([]*EventRecord
 	return records, nil
 }
 
-// validateResult is the JSON shape returned by the object.Validate contract.
-// Matches the official ScalarDL generic contracts response schema.
-type validateResult struct {
-	Status         string   `json:"status"`
-	Details        string   `json:"details"`
-	FaultyVersions []string `json:"faulty_versions"`
-}
-
 // Validate verifies the integrity of objectID against the caller-supplied
-// expectedHash. The hash comes from the vault (stored at submission time),
-// not from ScalarDL — breaking the circular trust where the system being
-// validated was also the source of expected values.
+// expectedHash from the vault. It fetches the stored record via Get and
+// performs three local checks:
+//
+//  1. The stored hash_value must equal expectedHash — detects direct hash
+//     manipulation in the ScalarDL database.
+//  2. If a "content" field is present in the record metadata, its SHA-256
+//     must equal expectedHash — detects content replacement.
+//  3. Individual metadata display fields (operation, label_hash) must match
+//     the authenticated content — detects targeted field tampering when
+//     hash_value and content are left intact (e.g. changing
+//     operation "hotp" → "totp" without touching the other fields).
+//
+// Events submitted before content storage was introduced pass check (1) only.
 func (c *LedgerClient) Validate(ctx context.Context, objectID, expectedHash string) (*ValidationResult, error) {
-	// Build versions array from caller-supplied expected hash (D-06).
-	// No Get() call — the hash comes from the vault, not ScalarDL.
-	versions := []map[string]string{
-		{
-			"version_id": objectID,
-			"hash_value": expectedHash,
-		},
-	}
-
-	contractID := "object.v1_0_0.Validate"
-	arg, err := json.Marshal(map[string]interface{}{
-		"object_id": objectID,
-		"versions":  versions,
-	})
+	records, err := c.Get(ctx, objectID)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling Validate argument: %w", err)
+		return nil, fmt.Errorf("fetching record for validation: %w", err)
+	}
+	if len(records) == 0 {
+		return &ValidationResult{
+			Valid:       false,
+			ErrorDetail: "no record found in ledger",
+		}, nil
+	}
+	record := records[len(records)-1]
+
+	// Check 1: stored hash_value must match the vault hash.
+	if record.HashValue != expectedHash {
+		return &ValidationResult{
+			Valid:       false,
+			ErrorDetail: "record hash has been altered",
+		}, nil
 	}
 
-	nonce := uuid.New().String()
-	formatted := formatArgument(string(arg), nonce)
-	sig, err := c.signer.Sign(contractID, formatted, nonce, c.entityID, c.keyVersion)
-	if err != nil {
-		return nil, fmt.Errorf("signing Validate request: %w", err)
-	}
+	// Checks 2 & 3: only run when content is present in metadata (events
+	// submitted after D-17). Check 2 recomputes SHA-256(content) to confirm
+	// content itself has not been replaced. Check 3 cross-checks individual
+	// display fields against the now-authenticated content to catch targeted
+	// field tampering (e.g. operation changed while content is left intact).
+	if content, ok := record.Metadata["content"].(string); ok && content != "" {
+		// Check 2: recompute SHA-256 of stored event content and compare.
+		sum := sha256.Sum256([]byte(content))
+		if hex.EncodeToString(sum[:]) != expectedHash {
+			return &ValidationResult{
+				Valid:       false,
+				ErrorDetail: "event content has been altered",
+			}, nil
+		}
 
-	resp, err := c.ledger.ExecuteContract(ctx, &rpc.ContractExecutionRequest{
-		ContractId:       contractID,
-		ContractArgument: formatted,
-		EntityId:         c.entityID,
-		KeyVersion:       c.keyVersion,
-		Signature:        sig,
-		Nonce:            nonce,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("%w: Validate contract failed: %s", tegerrors.ErrNetworkFailed, err)
-	}
-
-	var vr validateResult
-	if resp.GetContractResult() != "" {
-		if err := json.Unmarshal([]byte(resp.GetContractResult()), &vr); err != nil {
-			return nil, fmt.Errorf("parsing Validate result: %w", err)
+		// Check 3: individual display fields must match the authenticated content.
+		var evt AuthEvent
+		if jsonErr := json.Unmarshal([]byte(content), &evt); jsonErr == nil {
+			if op, ok := record.Metadata["operation"].(string); ok && op != evt.OperationType {
+				return &ValidationResult{
+					Valid:       false,
+					ErrorDetail: "event type field has been altered",
+				}, nil
+			}
+			if lh, ok := record.Metadata["label_hash"].(string); ok && lh != evt.LabelHash {
+				return &ValidationResult{
+					Valid:       false,
+					ErrorDetail: "credential field has been altered",
+				}, nil
+			}
 		}
 	}
 
-	return &ValidationResult{
-		Valid:       vr.Status == "correct",
-		ErrorDetail: vr.Details,
-	}, nil
+	return &ValidationResult{Valid: true}, nil
 }
 
 // RegisterCert registers the client certificate on the LedgerPrivileged service.
@@ -663,6 +676,11 @@ func (c *LedgerClient) Submit(ctx context.Context, entry QueueEntry) (string, er
 		return "", fmt.Errorf("serialising queue entry for submission: %w", err)
 	}
 	sum := sha256.Sum256(entryJSON)
+	// Capture the serialised event before zeroing. Stored as "content" in
+	// ScalarDL metadata so validation can recompute SHA-256(content) and
+	// detect metadata tampering even when hash_value is left intact (D-17).
+	// The event JSON contains only hashed/derived fields, not raw secrets.
+	eventContent := string(entryJSON)
 	for i := range entryJSON {
 		entryJSON[i] = 0
 	}
@@ -672,6 +690,7 @@ func (c *LedgerClient) Submit(ctx context.Context, entry QueueEntry) (string, er
 		"operation":  entry.Event.OperationType,
 		"label_hash": entry.Event.LabelHash,
 		"timestamp":  entry.Event.Timestamp.Unix(),
+		"content":    eventContent,
 	}
 
 	objectID := entry.Event.EventID

--- a/internal/audit/client.go
+++ b/internal/audit/client.go
@@ -40,8 +40,9 @@ type Client interface {
 	PutWithMetadata(ctx context.Context, objectID, hashValue string, metadata map[string]interface{}) error
 	// Get retrieves all event records for objectID from the ledger.
 	Get(ctx context.Context, objectID string) ([]*EventRecord, error)
-	// Validate verifies the integrity of all records for objectID on the ledger.
-	Validate(ctx context.Context, objectID string) (*ValidationResult, error)
+	// Validate verifies the integrity of objectID against the caller-supplied
+	// expectedHash. The hash comes from the vault, not from ScalarDL.
+	Validate(ctx context.Context, objectID, expectedHash string) (*ValidationResult, error)
 	// CollectionCreate creates a new collection with the given object IDs.
 	CollectionCreate(ctx context.Context, collectionID string, objectIDs []string) error
 	// CollectionAdd adds object IDs to an existing collection.
@@ -57,8 +58,9 @@ type Client interface {
 	// Close releases the underlying gRPC connection.
 	Close() error
 	// Submit stores each event as its own ScalarDL object with metadata and
-	// adds it to a per-entity collection.
-	Submit(ctx context.Context, entry QueueEntry) error
+	// adds it to a per-entity collection. Returns the computed hash value
+	// (hex-encoded SHA-256 of the event JSON) for vault storage.
+	Submit(ctx context.Context, entry QueueEntry) (string, error)
 }
 
 // EventRecord is a single record returned by a Get call.
@@ -519,37 +521,20 @@ type validateResult struct {
 	FaultyVersions []string `json:"faulty_versions"`
 }
 
-// Validate verifies the integrity of all records for objectID on the ledger.
-// It uses a two-step flow: first calls object.Get to retrieve stored records,
-// then calls object.Validate with a versions array built from those records.
-// If Get returns no records, it returns Valid=true with EventCount=0 without
-// calling object.Validate (nothing to validate).
-func (c *LedgerClient) Validate(ctx context.Context, objectID string) (*ValidationResult, error) {
-	// Step 1: Retrieve all stored records via object.Get.
-	records, err := c.Get(ctx, objectID)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving records for validation: %w", err)
+// Validate verifies the integrity of objectID against the caller-supplied
+// expectedHash. The hash comes from the vault (stored at submission time),
+// not from ScalarDL — breaking the circular trust where the system being
+// validated was also the source of expected values.
+func (c *LedgerClient) Validate(ctx context.Context, objectID, expectedHash string) (*ValidationResult, error) {
+	// Build versions array from caller-supplied expected hash (D-06).
+	// No Get() call — the hash comes from the vault, not ScalarDL.
+	versions := []map[string]string{
+		{
+			"version_id": objectID,
+			"hash_value": expectedHash,
+		},
 	}
 
-	// If no records exist, there is nothing to validate.
-	if len(records) == 0 {
-		return &ValidationResult{Valid: true, EventCount: 0}, nil
-	}
-
-	// Step 2: Build versions array from retrieved records.
-	// The HashStore object.Validate contract expects each version entry to
-	// contain "version_id" (the object ID string, not a numeric version) and
-	// "hash_value". This matches the HashStore SDK's ValidateRequest schema
-	// where version_id identifies the object, not a sequential version number.
-	versions := make([]map[string]string, len(records))
-	for i, r := range records {
-		versions[i] = map[string]string{
-			"version_id": r.ObjectID,
-			"hash_value": r.HashValue,
-		}
-	}
-
-	// Step 3: Marshal the validate argument with object_id and versions.
 	contractID := "object.v1_0_0.Validate"
 	arg, err := json.Marshal(map[string]interface{}{
 		"object_id": objectID,
@@ -559,7 +544,6 @@ func (c *LedgerClient) Validate(ctx context.Context, objectID string) (*Validati
 		return nil, fmt.Errorf("marshalling Validate argument: %w", err)
 	}
 
-	// Step 4: Sign and execute object.Validate.
 	nonce := uuid.New().String()
 	formatted := formatArgument(string(arg), nonce)
 	sig, err := c.signer.Sign(contractID, formatted, nonce, c.entityID, c.keyVersion)
@@ -579,7 +563,6 @@ func (c *LedgerClient) Validate(ctx context.Context, objectID string) (*Validati
 		return nil, fmt.Errorf("%w: Validate contract failed: %s", tegerrors.ErrNetworkFailed, err)
 	}
 
-	// Step 5: Parse and map the response.
 	var vr validateResult
 	if resp.GetContractResult() != "" {
 		if err := json.Unmarshal([]byte(resp.GetContractResult()), &vr); err != nil {
@@ -589,7 +572,7 @@ func (c *LedgerClient) Validate(ctx context.Context, objectID string) (*Validati
 
 	return &ValidationResult{
 		Valid:       vr.Status == "correct",
-		EventCount:  len(records),
+		EventCount:  1,
 		ErrorDetail: vr.Details,
 	}, nil
 }
@@ -674,11 +657,12 @@ func (c *LedgerClient) Close() error {
 
 // Submit implements the Submitter interface. Each event is stored as its own
 // ScalarDL object with metadata (operation, label hash, timestamp) and added
-// to a per-entity collection for listing.
-func (c *LedgerClient) Submit(ctx context.Context, entry QueueEntry) error {
+// to a per-entity collection for listing. Returns the computed hash value
+// (hex-encoded SHA-256 of the event JSON) so callers can store it in the vault.
+func (c *LedgerClient) Submit(ctx context.Context, entry QueueEntry) (string, error) {
 	entryJSON, err := json.Marshal(entry.Event)
 	if err != nil {
-		return fmt.Errorf("serialising queue entry for submission: %w", err)
+		return "", fmt.Errorf("serialising queue entry for submission: %w", err)
 	}
 	sum := sha256.Sum256(entryJSON)
 	for i := range entryJSON {
@@ -694,7 +678,7 @@ func (c *LedgerClient) Submit(ctx context.Context, entry QueueEntry) error {
 
 	objectID := entry.Event.EventID
 	if err := c.PutWithMetadata(ctx, objectID, hashValue, metadata); err != nil {
-		return err
+		return "", err
 	}
 
 	// Add the event to the entity's audit collection. If the collection
@@ -706,7 +690,7 @@ func (c *LedgerClient) Submit(ctx context.Context, entry QueueEntry) error {
 		// Only fall through to CollectionCreate when the collection does
 		// not exist. Transient or other errors should propagate immediately.
 		if !tegerrors.Is(err, errCollectionNotFound) {
-			return fmt.Errorf("adding event to collection: %w", err)
+			return "", fmt.Errorf("adding event to collection: %w", err)
 		}
 		createErr := c.CollectionCreate(ctx, collectionID, []string{objectID})
 		if createErr != nil {
@@ -714,14 +698,14 @@ func (c *LedgerClient) Submit(ctx context.Context, entry QueueEntry) error {
 				// Another caller created the collection between our Add
 				// and Create — retry Add now that the collection exists.
 				if retryErr := c.CollectionAdd(ctx, collectionID, []string{objectID}); retryErr != nil {
-					return fmt.Errorf("adding event to collection after retry: %w", retryErr)
+					return "", fmt.Errorf("adding event to collection after retry: %w", retryErr)
 				}
 			} else {
-				return fmt.Errorf("creating audit collection: %w", createErr)
+				return "", fmt.Errorf("creating audit collection: %w", createErr)
 			}
 		}
 	}
 
-	return nil
+	return hashValue, nil
 }
 

--- a/internal/audit/client.go
+++ b/internal/audit/client.go
@@ -74,7 +74,6 @@ type EventRecord struct {
 // ValidationResult is returned by Validate.
 type ValidationResult struct {
 	Valid       bool
-	EventCount  int
 	ErrorDetail string
 }
 
@@ -572,7 +571,6 @@ func (c *LedgerClient) Validate(ctx context.Context, objectID, expectedHash stri
 
 	return &ValidationResult{
 		Valid:       vr.Status == "correct",
-		EventCount:  1,
 		ErrorDetail: vr.Details,
 	}, nil
 }

--- a/internal/audit/client.go
+++ b/internal/audit/client.go
@@ -542,7 +542,15 @@ func (c *LedgerClient) Validate(ctx context.Context, objectID, expectedHash stri
 			ErrorDetail: "no record found in ledger",
 		}, nil
 	}
-	record := records[len(records)-1]
+	// Each event uses a UUID EventID written exactly once, so len > 1 is
+	// unexpected and is itself evidence of tampering or a replay.
+	if len(records) > 1 {
+		return &ValidationResult{
+			Valid:       false,
+			ErrorDetail: "unexpected multiple versions for event record",
+		}, nil
+	}
+	record := records[0]
 
 	// Check 1: stored hash_value must match the vault hash.
 	if record.HashValue != expectedHash {

--- a/internal/audit/client_integration_test.go
+++ b/internal/audit/client_integration_test.go
@@ -184,7 +184,7 @@ func TestIntegration_Validate(t *testing.T) {
 	}
 	t.Logf("Put succeeded: objectID=%s", objectID)
 
-	result, err := client.Validate(ctx, objectID)
+	result, err := client.Validate(ctx, objectID, hashValue)
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestIntegration_RegisterContracts(t *testing.T) {
 	t.Logf("object.Get contract verified: %d records", len(records))
 
 	// Verify Validate also works (object.Validate contract registered).
-	result, err := client.Validate(ctx, testObjID)
+	result, err := client.Validate(ctx, testObjID, testHash)
 	if err != nil {
 		t.Fatalf("Validate failed — object.Validate contract may not be registered: %v", err)
 	}
@@ -317,7 +317,7 @@ func TestIntegration_E2E_PutGetValidate(t *testing.T) {
 	t.Logf("Get event 1: %d records", len(records1))
 
 	// Step 3: Validate event 1 integrity.
-	result, err := client.Validate(ctx, objectID1)
+	result, err := client.Validate(ctx, objectID1, hash1)
 	if err != nil {
 		t.Fatalf("Validate event 1: %v", err)
 	}
@@ -493,7 +493,7 @@ func TestIntegration_HMAC_SubmitAndCollectionGet(t *testing.T) {
 		"",
 	)
 	entry := audit.QueueEntry{Event: evt}
-	if err := client.Submit(ctx, entry); err != nil {
+	if _, err := client.Submit(ctx, entry); err != nil {
 		t.Fatalf("Submit (HMAC): %v", err)
 	}
 	t.Logf("Submit succeeded: %s", evt.EventID)

--- a/internal/audit/client_integration_test.go
+++ b/internal/audit/client_integration_test.go
@@ -414,7 +414,7 @@ func TestIntegration_QueueFlush(t *testing.T) {
 	}
 
 	// Flush the queue to the live ScalarDL instance.
-	if err := q.Flush(ctx, client); err != nil {
+	if err := q.Flush(ctx, client, nil); err != nil {
 		t.Fatalf("Flush: %v", err)
 	}
 

--- a/internal/audit/client_integration_test.go
+++ b/internal/audit/client_integration_test.go
@@ -192,7 +192,7 @@ func TestIntegration_Validate(t *testing.T) {
 	if !result.Valid {
 		t.Errorf("Validate returned Valid=false: %s", result.ErrorDetail)
 	} else {
-		t.Logf("Validate succeeded: EventCount=%d", result.EventCount)
+		t.Logf("Validate succeeded")
 	}
 }
 
@@ -324,7 +324,7 @@ func TestIntegration_E2E_PutGetValidate(t *testing.T) {
 	if !result.Valid {
 		t.Errorf("Validate returned Valid=false for event 1: %s", result.ErrorDetail)
 	}
-	t.Logf("Validate event 1: Valid=%v EventCount=%d", result.Valid, result.EventCount)
+	t.Logf("Validate event 1: Valid=%v", result.Valid)
 }
 
 // TestIntegration_HistoryRetrieval verifies that events Put to the ledger can

--- a/internal/audit/client_test.go
+++ b/internal/audit/client_test.go
@@ -5,9 +5,12 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"math/big"
 	"net"
@@ -235,83 +238,180 @@ func newBufconnServerMulti(t *testing.T, ledger *mockLedgerServerMulti, privileg
 	return conn
 }
 
-// TestClient_ValidateArgSchema verifies that Validate calls object.v1_0_0.Validate
-// with a versions array containing the caller-supplied expectedHash. No Get call
-// is made — the hash comes from the vault, not ScalarDL.
-func TestClient_ValidateArgSchema(t *testing.T) {
+// buildGetResult returns a mock object.v1_0_0.Get JSON response containing
+// a single record with the given hash_value and metadata.
+func buildGetResult(t *testing.T, objectID, hashValue string, metadata map[string]interface{}) string {
+	t.Helper()
+	type record struct {
+		ObjectID  string                 `json:"object_id"`
+		HashValue string                 `json:"hash_value"`
+		Age       int                    `json:"age"`
+		Metadata  map[string]interface{} `json:"metadata,omitempty"`
+	}
+	b, err := json.Marshal([]record{{ObjectID: objectID, HashValue: hashValue, Age: 0, Metadata: metadata}})
+	if err != nil {
+		t.Fatalf("buildGetResult: %v", err)
+	}
+	return string(b)
+}
+
+// TestClient_Validate_ValidRecord verifies that Validate returns Valid=true
+// when the stored hash_value and content both match the vault hash.
+func TestClient_Validate_ValidRecord(t *testing.T) {
 	signer := &mockSigner{sig: []byte("fake-sig")}
 
-	// The Validate response returns correct status.
-	validateResult := `{"status":"correct","details":"","faulty_versions":[]}`
+	content := `{"event_id":"tegata-test","op_type":"totp","label_hash":"lhash","service_hash":"shash","host":"h1","success":true,"timestamp":"2024-01-01T00:00:00Z"}`
+	sum := sha256.Sum256([]byte(content))
+	hashValue := hex.EncodeToString(sum[:])
 
-	ledgerSrv := &mockLedgerServerMulti{
-		results: []string{validateResult},
-	}
-	privSrv := &mockPrivilegedServer{}
-	conn := newBufconnServerMulti(t, ledgerSrv, privSrv)
+	getResult := buildGetResult(t, "tegata-test", hashValue, map[string]interface{}{"content": content})
+	ledgerSrv := &mockLedgerServerMulti{results: []string{getResult}}
+	conn := newBufconnServerMulti(t, ledgerSrv, &mockPrivilegedServer{})
 
 	client := audit.NewLedgerClientFromConn(conn, nil, signer, "test-entity", 1)
 	defer func() { _ = client.Close() }()
 
-	result, err := client.Validate(context.Background(), "tegata-", "abc123")
+	result, err := client.Validate(context.Background(), "tegata-test", hashValue)
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
-
-	// Verify exactly one ExecuteContract call was made (Validate only, no Get).
-	if len(ledgerSrv.calls) != 1 {
-		t.Fatalf("expected 1 ExecuteContract call, got %d", len(ledgerSrv.calls))
-	}
-
-	// The call should be object.v1_0_0.Validate with versions array.
-	if ledgerSrv.calls[0].ContractId != "object.v1_0_0.Validate" {
-		t.Errorf("call contract ID = %q, want %q", ledgerSrv.calls[0].ContractId, "object.v1_0_0.Validate")
-	}
-
-	// The argument must contain the caller-supplied hash in the versions array.
-	arg := ledgerSrv.calls[0].ContractArgument
-	if !strings.Contains(arg, `"versions"`) {
-		t.Errorf("Validate argument missing 'versions' key: %s", arg)
-	}
-	if !strings.Contains(arg, `"object_id"`) {
-		t.Errorf("Validate argument missing 'object_id' key: %s", arg)
-	}
-	if !strings.Contains(arg, `"abc123"`) {
-		t.Errorf("Validate argument missing expected hash 'abc123': %s", arg)
-	}
-
 	if !result.Valid {
-		t.Error("expected Valid=true, got false")
+		t.Errorf("expected Valid=true, got false: %s", result.ErrorDetail)
+	}
+	// Validate uses Get (one call), not object.v1_0_0.Validate.
+	if len(ledgerSrv.calls) != 1 || ledgerSrv.calls[0].ContractId != "object.v1_0_0.Get" {
+		t.Errorf("expected one Get call, got %d calls; first=%q", len(ledgerSrv.calls), func() string {
+			if len(ledgerSrv.calls) > 0 {
+				return ledgerSrv.calls[0].ContractId
+			}
+			return ""
+		}())
 	}
 }
 
-// TestClient_ValidateTampered verifies that when the ScalarDL Validate contract
-// returns a "tampered" status, the result reflects Invalid with error detail.
-func TestClient_ValidateTampered(t *testing.T) {
+// TestClient_Validate_HashValueTampered verifies that Validate returns
+// Valid=false when the stored hash_value differs from the vault hash.
+func TestClient_Validate_HashValueTampered(t *testing.T) {
 	signer := &mockSigner{sig: []byte("fake-sig")}
 
-	// The Validate response returns faulty status (ScalarDL's term for tampered).
-	validateResult := `{"status":"faulty","details":"A faulty version is found.","faulty_versions":["tegata-"]}`
-
-	ledgerSrv := &mockLedgerServerMulti{
-		results: []string{validateResult},
-	}
-	privSrv := &mockPrivilegedServer{}
-	conn := newBufconnServerMulti(t, ledgerSrv, privSrv)
+	getResult := buildGetResult(t, "tegata-test", "differenthash", nil)
+	ledgerSrv := &mockLedgerServerMulti{results: []string{getResult}}
+	conn := newBufconnServerMulti(t, ledgerSrv, &mockPrivilegedServer{})
 
 	client := audit.NewLedgerClientFromConn(conn, nil, signer, "test-entity", 1)
 	defer func() { _ = client.Close() }()
 
-	result, err := client.Validate(context.Background(), "tegata-", "wronghash")
+	result, err := client.Validate(context.Background(), "tegata-test", "vaulthash")
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
-
 	if result.Valid {
-		t.Error("expected Valid=false for tampered record, got true")
+		t.Error("expected Valid=false when hash_value is tampered, got true")
 	}
 	if result.ErrorDetail == "" {
-		t.Error("expected non-empty ErrorDetail for tampered record")
+		t.Error("expected non-empty ErrorDetail")
+	}
+}
+
+// TestClient_Validate_ContentTampered verifies that Validate returns Valid=false
+// when metadata content is changed even though hash_value is left intact.
+func TestClient_Validate_ContentTampered(t *testing.T) {
+	signer := &mockSigner{sig: []byte("fake-sig")}
+
+	// Original content and its hash.
+	content := `{"event_id":"tegata-test","op_type":"totp","label_hash":"lhash","service_hash":"shash","host":"h1","success":true,"timestamp":"2024-01-01T00:00:00Z"}`
+	sum := sha256.Sum256([]byte(content))
+	hashValue := hex.EncodeToString(sum[:])
+
+	// Stored record has the correct hash_value but tampered content.
+	tamperedContent := strings.Replace(content, "totp", "hotp", 1)
+	getResult := buildGetResult(t, "tegata-test", hashValue, map[string]interface{}{"content": tamperedContent})
+	ledgerSrv := &mockLedgerServerMulti{results: []string{getResult}}
+	conn := newBufconnServerMulti(t, ledgerSrv, &mockPrivilegedServer{})
+
+	client := audit.NewLedgerClientFromConn(conn, nil, signer, "test-entity", 1)
+	defer func() { _ = client.Close() }()
+
+	result, err := client.Validate(context.Background(), "tegata-test", hashValue)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if result.Valid {
+		t.Error("expected Valid=false when content is tampered, got true")
+	}
+	if !strings.Contains(result.ErrorDetail, "event content has been altered") {
+		t.Errorf("expected 'event content has been altered' in ErrorDetail, got %q", result.ErrorDetail)
+	}
+}
+
+// TestClient_Validate_MetadataOperationTampered verifies that Validate returns
+// Valid=false when metadata.operation is changed while hash_value and content
+// are left intact (Check 3: cross-field consistency).
+func TestClient_Validate_MetadataOperationTampered(t *testing.T) {
+	signer := &mockSigner{sig: []byte("fake-sig")}
+
+	// Build a valid AuthEvent JSON for content (field names match AuthEvent struct tags).
+	content := `{"event_id":"tegata-test","timestamp":"2024-01-01T00:00:00Z","operation_type":"hotp","label_hash":"lhash","service_hash":"shash","host_hash":"hhash","success":true,"prev_hash":""}`
+	sum := sha256.Sum256([]byte(content))
+	hashValue := hex.EncodeToString(sum[:])
+
+	// metadata.operation is changed to "totp" but content (with "hotp") is left intact.
+	metadata := map[string]interface{}{
+		"content":    content,
+		"operation":  "totp", // tampered: original was "hotp" per content
+		"label_hash": "lhash",
+	}
+	getResult := buildGetResult(t, "tegata-test", hashValue, metadata)
+	ledgerSrv := &mockLedgerServerMulti{results: []string{getResult}}
+	conn := newBufconnServerMulti(t, ledgerSrv, &mockPrivilegedServer{})
+
+	client := audit.NewLedgerClientFromConn(conn, nil, signer, "test-entity", 1)
+	defer func() { _ = client.Close() }()
+
+	result, err := client.Validate(context.Background(), "tegata-test", hashValue)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if result.Valid {
+		t.Error("expected Valid=false when metadata.operation is tampered, got true")
+	}
+	if !strings.Contains(result.ErrorDetail, "event type field has been altered") {
+		t.Errorf("expected 'event type field has been altered' in ErrorDetail, got %q", result.ErrorDetail)
+	}
+}
+
+// TestClient_Validate_MetadataLabelHashTampered verifies that Validate returns
+// Valid=false when metadata.label_hash is changed while hash_value and content
+// are left intact (Check 3: cross-field consistency).
+func TestClient_Validate_MetadataLabelHashTampered(t *testing.T) {
+	signer := &mockSigner{sig: []byte("fake-sig")}
+
+	content := `{"event_id":"tegata-test","timestamp":"2024-01-01T00:00:00Z","operation_type":"hotp","label_hash":"lhash","service_hash":"shash","host_hash":"hhash","success":true,"prev_hash":""}`
+	sum := sha256.Sum256([]byte(content))
+	hashValue := hex.EncodeToString(sum[:])
+
+	// metadata.label_hash is changed but content (with original label_hash) is left intact.
+	metadata := map[string]interface{}{
+		"content":    content,
+		"operation":  "hotp",
+		"label_hash": "tampered-label-hash", // tampered: original was "lhash" per content
+	}
+	getResult := buildGetResult(t, "tegata-test", hashValue, metadata)
+	ledgerSrv := &mockLedgerServerMulti{results: []string{getResult}}
+	conn := newBufconnServerMulti(t, ledgerSrv, &mockPrivilegedServer{})
+
+	client := audit.NewLedgerClientFromConn(conn, nil, signer, "test-entity", 1)
+	defer func() { _ = client.Close() }()
+
+	result, err := client.Validate(context.Background(), "tegata-test", hashValue)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if result.Valid {
+		t.Error("expected Valid=false when metadata.label_hash is tampered, got true")
+	}
+	if !strings.Contains(result.ErrorDetail, "credential field has been altered") {
+		t.Errorf("expected 'credential field has been altered' in ErrorDetail, got %q", result.ErrorDetail)
 	}
 }
 

--- a/internal/audit/client_test.go
+++ b/internal/audit/client_test.go
@@ -280,12 +280,8 @@ func TestClient_ValidateArgSchema(t *testing.T) {
 		t.Errorf("Validate argument missing expected hash 'abc123': %s", arg)
 	}
 
-	// Result should be valid with 1 event.
 	if !result.Valid {
 		t.Error("expected Valid=true, got false")
-	}
-	if result.EventCount != 1 {
-		t.Errorf("EventCount = %d, want 1", result.EventCount)
 	}
 }
 
@@ -294,8 +290,8 @@ func TestClient_ValidateArgSchema(t *testing.T) {
 func TestClient_ValidateTampered(t *testing.T) {
 	signer := &mockSigner{sig: []byte("fake-sig")}
 
-	// The Validate response returns tampered status.
-	validateResult := `{"status":"tampered","details":"hash mismatch at version tegata-","faulty_versions":["tegata-"]}`
+	// The Validate response returns faulty status (ScalarDL's term for tampered).
+	validateResult := `{"status":"faulty","details":"A faulty version is found.","faulty_versions":["tegata-"]}`
 
 	ledgerSrv := &mockLedgerServerMulti{
 		results: []string{validateResult},
@@ -313,9 +309,6 @@ func TestClient_ValidateTampered(t *testing.T) {
 
 	if result.Valid {
 		t.Error("expected Valid=false for tampered record, got true")
-	}
-	if result.EventCount != 1 {
-		t.Errorf("EventCount = %d, want 1", result.EventCount)
 	}
 	if result.ErrorDetail == "" {
 		t.Error("expected non-empty ErrorDetail for tampered record")

--- a/internal/audit/client_test.go
+++ b/internal/audit/client_test.go
@@ -235,19 +235,17 @@ func newBufconnServerMulti(t *testing.T, ledger *mockLedgerServerMulti, privileg
 	return conn
 }
 
-// TestClient_ValidateArgSchema verifies that Validate calls object.v1_0_0.Get first,
-// then object.v1_0_0.Validate with a versions array containing version_id and
-// hash_value pairs from the Get result.
+// TestClient_ValidateArgSchema verifies that Validate calls object.v1_0_0.Validate
+// with a versions array containing the caller-supplied expectedHash. No Get call
+// is made — the hash comes from the vault, not ScalarDL.
 func TestClient_ValidateArgSchema(t *testing.T) {
 	signer := &mockSigner{sig: []byte("fake-sig")}
 
-	// The Get response returns two records.
-	getResult := `[{"object_id":"evt-001","hash_value":"aaa","age":100},{"object_id":"evt-002","hash_value":"bbb","age":200}]`
 	// The Validate response returns correct status.
 	validateResult := `{"status":"correct","details":"","faulty_versions":[]}`
 
 	ledgerSrv := &mockLedgerServerMulti{
-		results: []string{getResult, validateResult},
+		results: []string{validateResult},
 	}
 	privSrv := &mockPrivilegedServer{}
 	conn := newBufconnServerMulti(t, ledgerSrv, privSrv)
@@ -255,52 +253,52 @@ func TestClient_ValidateArgSchema(t *testing.T) {
 	client := audit.NewLedgerClientFromConn(conn, nil, signer, "test-entity", 1)
 	defer func() { _ = client.Close() }()
 
-	result, err := client.Validate(context.Background(), "tegata-")
+	result, err := client.Validate(context.Background(), "tegata-", "abc123")
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
 
-	// Verify two ExecuteContract calls were made (Get + Validate).
-	if len(ledgerSrv.calls) != 2 {
-		t.Fatalf("expected 2 ExecuteContract calls, got %d", len(ledgerSrv.calls))
+	// Verify exactly one ExecuteContract call was made (Validate only, no Get).
+	if len(ledgerSrv.calls) != 1 {
+		t.Fatalf("expected 1 ExecuteContract call, got %d", len(ledgerSrv.calls))
 	}
 
-	// First call should be object.v1_0_0.Get.
-	if ledgerSrv.calls[0].ContractId != "object.v1_0_0.Get" {
-		t.Errorf("first call contract ID = %q, want %q", ledgerSrv.calls[0].ContractId, "object.v1_0_0.Get")
+	// The call should be object.v1_0_0.Validate with versions array.
+	if ledgerSrv.calls[0].ContractId != "object.v1_0_0.Validate" {
+		t.Errorf("call contract ID = %q, want %q", ledgerSrv.calls[0].ContractId, "object.v1_0_0.Validate")
 	}
 
-	// Second call should be object.v1_0_0.Validate with versions array.
-	if ledgerSrv.calls[1].ContractId != "object.v1_0_0.Validate" {
-		t.Errorf("second call contract ID = %q, want %q", ledgerSrv.calls[1].ContractId, "object.v1_0_0.Validate")
-	}
-
-	// The second call's argument must contain "versions" and "object_id" keys.
-	arg := ledgerSrv.calls[1].ContractArgument
+	// The argument must contain the caller-supplied hash in the versions array.
+	arg := ledgerSrv.calls[0].ContractArgument
 	if !strings.Contains(arg, `"versions"`) {
 		t.Errorf("Validate argument missing 'versions' key: %s", arg)
 	}
 	if !strings.Contains(arg, `"object_id"`) {
 		t.Errorf("Validate argument missing 'object_id' key: %s", arg)
 	}
+	if !strings.Contains(arg, `"abc123"`) {
+		t.Errorf("Validate argument missing expected hash 'abc123': %s", arg)
+	}
 
-	// Result should be valid with 2 events.
+	// Result should be valid with 1 event.
 	if !result.Valid {
 		t.Error("expected Valid=true, got false")
 	}
-	if result.EventCount != 2 {
-		t.Errorf("EventCount = %d, want 2", result.EventCount)
+	if result.EventCount != 1 {
+		t.Errorf("EventCount = %d, want 1", result.EventCount)
 	}
 }
 
-// TestClient_ValidateEmptyRecords verifies that when Get returns no records,
-// Validate returns Valid=true with EventCount=0 without making a second RPC call.
-func TestClient_ValidateEmptyRecords(t *testing.T) {
+// TestClient_ValidateTampered verifies that when the ScalarDL Validate contract
+// returns a "tampered" status, the result reflects Invalid with error detail.
+func TestClient_ValidateTampered(t *testing.T) {
 	signer := &mockSigner{sig: []byte("fake-sig")}
 
-	// The Get response returns an empty array.
+	// The Validate response returns tampered status.
+	validateResult := `{"status":"tampered","details":"hash mismatch at version tegata-","faulty_versions":["tegata-"]}`
+
 	ledgerSrv := &mockLedgerServerMulti{
-		results: []string{"[]"},
+		results: []string{validateResult},
 	}
 	privSrv := &mockPrivilegedServer{}
 	conn := newBufconnServerMulti(t, ledgerSrv, privSrv)
@@ -308,21 +306,19 @@ func TestClient_ValidateEmptyRecords(t *testing.T) {
 	client := audit.NewLedgerClientFromConn(conn, nil, signer, "test-entity", 1)
 	defer func() { _ = client.Close() }()
 
-	result, err := client.Validate(context.Background(), "tegata-")
+	result, err := client.Validate(context.Background(), "tegata-", "wronghash")
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
 
-	// Only one call should have been made (Get only, no Validate).
-	if len(ledgerSrv.calls) != 1 {
-		t.Fatalf("expected 1 ExecuteContract call (Get only), got %d", len(ledgerSrv.calls))
+	if result.Valid {
+		t.Error("expected Valid=false for tampered record, got true")
 	}
-
-	if !result.Valid {
-		t.Error("expected Valid=true for empty records, got false")
+	if result.EventCount != 1 {
+		t.Errorf("EventCount = %d, want 1", result.EventCount)
 	}
-	if result.EventCount != 0 {
-		t.Errorf("EventCount = %d, want 0", result.EventCount)
+	if result.ErrorDetail == "" {
+		t.Error("expected non-empty ErrorDetail for tampered record")
 	}
 }
 

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -296,7 +296,9 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// All callers issue UPDATE statements targeting a single row. runSQL asserts
 	// that psql reports "UPDATE 1" so that a silent zero-row update (e.g. due to
 	// a wrong object ID prefix) fails immediately with a clear message rather
-	// than letting assertTampering fail with a confusing Valid=true.
+	// than letting assertTampering fail with a confusing Valid=true. The id value
+	// interpolated into each SQL string is always a UUID from evt.EventID (hex
+	// digits and hyphens only), so fmt.Sprintf is safe here.
 	runSQL := func(t *testing.T, sql string) {
 		t.Helper()
 		out, err := exec.Command(

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -288,6 +289,11 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// container via docker exec. The container name is always
 	// tegata-ledger-postgres-1 because the compose project name is fixed to
 	// "tegata-ledger" in docker-compose.yml.
+	//
+	// All callers issue UPDATE statements targeting a single row. runSQL asserts
+	// that psql reports "UPDATE 1" so that a silent zero-row update (e.g. due to
+	// a wrong object ID prefix) fails immediately with a clear message rather
+	// than letting assertTampering fail with a confusing Valid=true.
 	runSQL := func(t *testing.T, sql string) {
 		t.Helper()
 		out, err := exec.Command(
@@ -296,6 +302,16 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 		).CombinedOutput()
 		if err != nil {
 			t.Fatalf("psql: %v\n%s", err, out)
+		}
+		found := false
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.TrimSpace(line) == "UPDATE 1" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("psql UPDATE affected != 1 row; verify the \"o_\" object ID prefix convention\n%s", out)
 		}
 	}
 
@@ -349,6 +365,7 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// Check 1: hash_value in the stored output replaced with a different value.
 	t.Run("HashValueTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
+		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline: fresh event must be valid
@@ -364,6 +381,7 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// matches hash_value even though hash_value itself is untouched.
 	t.Run("ContentTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
+		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline
@@ -379,6 +397,7 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// left intact, testing the cross-field consistency check.
 	t.Run("OperationFieldTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
+		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline
@@ -394,6 +413,7 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// left intact, testing the cross-field consistency check.
 	t.Run("LabelHashTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
+		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -244,3 +244,164 @@ func TestIntegration_StopStack_NonExistentCompose(t *testing.T) {
 	// Docker compose should fail with a file-not-found or similar error.
 	t.Logf("StopStack_NonExistentCompose verified: returned expected error: %v", err)
 }
+
+// TestIntegration_TamperingDetection spins up a full Docker stack, submits
+// real audit events via the production Submit path, then directly manipulates
+// the ScalarDL PostgreSQL database to simulate an attacker bypassing the gRPC
+// contracts. It asserts that client.Validate detects each of the four
+// supported tampering scenarios:
+//
+//   - Check 1: hash_value replaced — "record hash has been altered"
+//   - Check 2: content replaced — "event content has been altered"
+//   - Check 3a: metadata.operation changed — "event type field has been altered"
+//   - Check 3b: metadata.label_hash changed — "credential field has been altered"
+//
+// Each subtest submits its own fresh event so subtests are fully independent.
+// The replay-attack guard (len(records) > 1) is not covered here because the
+// object.v1_0_0.Get contract always returns a single record regardless of how
+// many rows exist in scalar.asset — see the comment in client.go Validate and
+// commit 849b42f for the full reasoning.
+func TestIntegration_TamperingDetection(t *testing.T) {
+	requireDocker(t)
+
+	srcDir, err := composeSourceDir()
+	if err != nil {
+		t.Fatalf("determining compose source directory: %v", err)
+	}
+	composeWorkDir := t.TempDir()
+	fsys := os.DirFS(srcDir)
+
+	cfg, err := audit.SetupStack(fsys, composeWorkDir, "test-vault-tampering", nil, nil)
+	if err != nil {
+		t.Fatalf("SetupStack: %v", err)
+	}
+	composePath := filepath.Join(composeWorkDir, "docker-compose.yml")
+	t.Cleanup(func() { _ = audit.TeardownStack(composePath) })
+
+	client, err := audit.NewClientFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("creating ledger client: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	// runSQL executes a SQL statement directly in the ScalarDL PostgreSQL
+	// container via docker exec. The container name is always
+	// tegata-ledger-postgres-1 because the compose project name is fixed to
+	// "tegata-ledger" in docker-compose.yml.
+	runSQL := func(t *testing.T, sql string) {
+		t.Helper()
+		out, err := exec.Command(
+			"docker", "exec", "tegata-ledger-postgres-1",
+			"psql", "-U", "scalardl", "-d", "scalardl", "-c", sql,
+		).CombinedOutput()
+		if err != nil {
+			t.Fatalf("psql: %v\n%s", err, out)
+		}
+	}
+
+	// submitEvent submits a fresh signed event via the production Submit path
+	// and returns its objectID and the vault hash value.
+	submitEvent := func(t *testing.T, opType string) (objectID, hashValue string) {
+		t.Helper()
+		evt := audit.NewAuthEvent(opType, "test-label", "test-service", "test-host", true, "")
+		entry := audit.QueueEntry{Event: evt}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		hash, err := client.Submit(ctx, entry)
+		if err != nil {
+			t.Fatalf("Submit(%s): %v", opType, err)
+		}
+		return evt.EventID, hash
+	}
+
+	// assertTampering calls Validate and asserts Valid=false with the expected
+	// ErrorDetail message.
+	assertTampering := func(t *testing.T, objectID, hashValue, wantDetail string) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		result, err := client.Validate(ctx, objectID, hashValue)
+		if err != nil {
+			t.Fatalf("Validate: unexpected error: %v", err)
+		}
+		if result.Valid {
+			t.Error("Validate: expected Valid=false after tampering, got Valid=true")
+		}
+		if result.ErrorDetail != wantDetail {
+			t.Errorf("Validate ErrorDetail = %q, want %q", result.ErrorDetail, wantDetail)
+		}
+	}
+
+	// assertClean calls Validate and asserts Valid=true.
+	assertClean := func(t *testing.T, objectID, hashValue string) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		result, err := client.Validate(ctx, objectID, hashValue)
+		if err != nil {
+			t.Fatalf("Validate: unexpected error: %v", err)
+		}
+		if !result.Valid {
+			t.Errorf("Validate: expected Valid=true, got Valid=false: %s", result.ErrorDetail)
+		}
+	}
+
+	// Check 1: hash_value in the stored output replaced with a different value.
+	t.Run("HashValueTampered", func(t *testing.T) {
+		objectID, hashValue := submitEvent(t, "totp")
+		dbID := "o_" + objectID
+
+		assertClean(t, objectID, hashValue) // baseline: fresh event must be valid
+
+		runSQL(t, fmt.Sprintf(
+			`UPDATE scalar.asset SET output = jsonb_set(output::jsonb, '{hash_value}', '"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"')::text WHERE id = '%s';`,
+			dbID,
+		))
+		assertTampering(t, objectID, hashValue, "record hash has been altered")
+	})
+
+	// Check 2: metadata.content replaced, so SHA-256(content) no longer
+	// matches hash_value even though hash_value itself is untouched.
+	t.Run("ContentTampered", func(t *testing.T) {
+		objectID, hashValue := submitEvent(t, "totp")
+		dbID := "o_" + objectID
+
+		assertClean(t, objectID, hashValue) // baseline
+
+		runSQL(t, fmt.Sprintf(
+			`UPDATE scalar.asset SET output = jsonb_set(output::jsonb, '{metadata,content}', to_jsonb((output::jsonb->'metadata'->>'content') || 'X'))::text WHERE id = '%s';`,
+			dbID,
+		))
+		assertTampering(t, objectID, hashValue, "event content has been altered")
+	})
+
+	// Check 3a: metadata.operation changed while hash_value and content are
+	// left intact, testing the cross-field consistency check.
+	t.Run("OperationFieldTampered", func(t *testing.T) {
+		objectID, hashValue := submitEvent(t, "totp")
+		dbID := "o_" + objectID
+
+		assertClean(t, objectID, hashValue) // baseline
+
+		runSQL(t, fmt.Sprintf(
+			`UPDATE scalar.asset SET output = jsonb_set(output::jsonb, '{metadata,operation}', '"hotp"')::text WHERE id = '%s';`,
+			dbID,
+		))
+		assertTampering(t, objectID, hashValue, "event type field has been altered")
+	})
+
+	// Check 3b: metadata.label_hash zeroed while hash_value and content are
+	// left intact, testing the cross-field consistency check.
+	t.Run("LabelHashTampered", func(t *testing.T) {
+		objectID, hashValue := submitEvent(t, "totp")
+		dbID := "o_" + objectID
+
+		assertClean(t, objectID, hashValue) // baseline
+
+		runSQL(t, fmt.Sprintf(
+			`UPDATE scalar.asset SET output = jsonb_set(output::jsonb, '{metadata,label_hash}', '"0000000000000000000000000000000000000000000000000000000000000000"')::text WHERE id = '%s';`,
+			dbID,
+		))
+		assertTampering(t, objectID, hashValue, "credential field has been altered")
+	})
+}

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -258,6 +258,8 @@ func TestIntegration_StopStack_NonExistentCompose(t *testing.T) {
 //   - Check 3b: metadata.label_hash changed — "credential field has been altered"
 //
 // Each subtest submits its own fresh event so subtests are fully independent.
+// ScalarDL stores object IDs in scalar.asset with an "o_" prefix, so each
+// subtest constructs dbID = "o_" + objectID when targeting the database row.
 // The replay-attack guard (len(records) > 1) is not covered here because the
 // object.v1_0_0.Get contract always returns a single record regardless of how
 // many rows exist in scalar.asset — see the comment in client.go Validate and
@@ -288,7 +290,8 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// runSQL executes a SQL statement directly in the ScalarDL PostgreSQL
 	// container via docker exec. The container name is always
 	// tegata-ledger-postgres-1 because the compose project name is fixed to
-	// "tegata-ledger" in docker-compose.yml.
+	// "tegata-ledger" in docker-compose.yml (see the `name:` field at the top
+	// of that file). If the compose project name changes, update this string.
 	//
 	// All callers issue UPDATE statements targeting a single row. runSQL asserts
 	// that psql reports "UPDATE 1" so that a silent zero-row update (e.g. due to
@@ -348,7 +351,9 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 		}
 	}
 
-	// assertClean calls Validate and asserts Valid=true.
+	// assertClean calls Validate and asserts Valid=true. Uses t.Fatalf so a
+	// baseline failure stops the subtest immediately rather than letting the
+	// subsequent mutation run and produce a misleading second failure.
 	assertClean := func(t *testing.T, objectID, hashValue string) {
 		t.Helper()
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -358,14 +363,13 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 			t.Fatalf("Validate: unexpected error: %v", err)
 		}
 		if !result.Valid {
-			t.Errorf("Validate: expected Valid=true, got Valid=false: %s", result.ErrorDetail)
+			t.Fatalf("Validate: expected Valid=true, got Valid=false: %s", result.ErrorDetail)
 		}
 	}
 
 	// Check 1: hash_value in the stored output replaced with a different value.
 	t.Run("HashValueTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
-		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline: fresh event must be valid
@@ -381,7 +385,6 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// matches hash_value even though hash_value itself is untouched.
 	t.Run("ContentTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
-		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline
@@ -397,7 +400,6 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// left intact, testing the cross-field consistency check.
 	t.Run("OperationFieldTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
-		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline
@@ -413,7 +415,6 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// left intact, testing the cross-field consistency check.
 	t.Run("LabelHashTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
-		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline

--- a/internal/audit/history.go
+++ b/internal/audit/history.go
@@ -77,6 +77,7 @@ func FetchHistory(ctx context.Context, client Client, entityID string) (*FetchHi
 type VerifyResult struct {
 	Valid       bool
 	EventCount  int
+	Skipped     int      // events without vault hash (pre-existing, per D-09)
 	Faults      []string // per-event error descriptions
 	ErrorDetail string   // summary when !Valid
 }
@@ -84,8 +85,9 @@ type VerifyResult struct {
 // VerifyByLabelHash validates the integrity of audit events for the given
 // entity that match labelHash. Only events whose label_hash metadata field
 // equals labelHash are validated; all others are ignored. If no matching
-// events exist, returns valid with zero events.
-func VerifyByLabelHash(ctx context.Context, client Client, entityID, labelHash string) (*VerifyResult, error) {
+// events exist, returns valid with zero events. Events without a vault hash
+// entry are skipped (pre-existing events, per D-09).
+func VerifyByLabelHash(ctx context.Context, client Client, entityID, labelHash string, vaultHashes map[string]string) (*VerifyResult, error) {
 	history, err := FetchHistory(ctx, client, entityID)
 	if err != nil {
 		return nil, err
@@ -102,10 +104,17 @@ func VerifyByLabelHash(ctx context.Context, client Client, entityID, labelHash s
 		return &VerifyResult{Valid: true, EventCount: 0}, nil
 	}
 
-	// TODO: parallelize Validate calls if per-credential event counts grow large.
 	var faults []string
+	var verified int
+	var skipped int
 	for _, id := range matchingIDs {
-		result, err := client.Validate(ctx, id)
+		expectedHash, ok := vaultHashes[id]
+		if !ok {
+			skipped++
+			continue
+		}
+		verified++
+		result, err := client.Validate(ctx, id, expectedHash)
 		if err != nil {
 			faults = append(faults, fmt.Sprintf("%s: error: %v", id, err))
 			continue
@@ -117,19 +126,22 @@ func VerifyByLabelHash(ctx context.Context, client Client, entityID, labelHash s
 
 	vr := &VerifyResult{
 		Valid:      len(faults) == 0,
-		EventCount: len(matchingIDs),
+		EventCount: verified,
+		Skipped:    skipped,
 		Faults:     faults,
 	}
 	if !vr.Valid {
-		vr.ErrorDetail = fmt.Sprintf("%d of %d events failed", len(faults), len(matchingIDs))
+		vr.ErrorDetail = fmt.Sprintf("%d of %d events failed", len(faults), verified)
 	}
 	return vr, nil
 }
 
 // VerifyAll validates the integrity of all audit events for the given entity.
-// It fetches the entity's collection, then validates each event individually.
-// If the collection does not exist (e.g. after a wipe), returns valid with zero events.
-func VerifyAll(ctx context.Context, client Client, entityID string) (*VerifyResult, error) {
+// It fetches the entity's collection, then validates each event individually
+// using the caller-supplied vaultHashes map. Events without a vault hash entry
+// are skipped (pre-existing events, per D-09). If the collection does not exist
+// (e.g. after a wipe), returns valid with zero events.
+func VerifyAll(ctx context.Context, client Client, entityID string, vaultHashes map[string]string) (*VerifyResult, error) {
 	collectionID := CollectionID(entityID)
 	eventIDs, err := client.CollectionGet(ctx, collectionID)
 	if err != nil {
@@ -146,8 +158,16 @@ func VerifyAll(ctx context.Context, client Client, entityID string) (*VerifyResu
 	}
 
 	var faults []string
+	var verified int
+	var skipped int
 	for _, id := range eventIDs {
-		result, err := client.Validate(ctx, id)
+		expectedHash, ok := vaultHashes[id]
+		if !ok {
+			skipped++
+			continue
+		}
+		verified++
+		result, err := client.Validate(ctx, id, expectedHash)
 		if err != nil {
 			faults = append(faults, fmt.Sprintf("%s: error: %v", id, err))
 			continue
@@ -159,11 +179,12 @@ func VerifyAll(ctx context.Context, client Client, entityID string) (*VerifyResu
 
 	vr := &VerifyResult{
 		Valid:      len(faults) == 0,
-		EventCount: len(eventIDs),
+		EventCount: verified,
+		Skipped:    skipped,
 		Faults:     faults,
 	}
 	if !vr.Valid {
-		vr.ErrorDetail = fmt.Sprintf("%d of %d events failed", len(faults), len(eventIDs))
+		vr.ErrorDetail = fmt.Sprintf("%d of %d events failed", len(faults), verified)
 	}
 	return vr, nil
 }

--- a/internal/audit/history_test.go
+++ b/internal/audit/history_test.go
@@ -29,7 +29,7 @@ func (m *mockClient) Get(ctx context.Context, objectID string) ([]*audit.EventRe
 	return nil, nil
 }
 
-func (m *mockClient) Validate(ctx context.Context, objectID string) (*audit.ValidationResult, error) {
+func (m *mockClient) Validate(ctx context.Context, objectID, expectedHash string) (*audit.ValidationResult, error) {
 	if result, ok := m.validate[objectID]; ok {
 		return result, nil
 	}
@@ -64,7 +64,7 @@ func (m *mockClient) Close() error {
 	return nil
 }
 
-func (m *mockClient) Submit(ctx context.Context, entry audit.QueueEntry) error {
+func (m *mockClient) Submit(ctx context.Context, entry audit.QueueEntry) (string, error) {
 	panic("unimplemented")
 }
 
@@ -167,8 +167,13 @@ func TestVerifyByLabelHash_AllValid(t *testing.T) {
 			"evt-2": {Valid: true},
 		},
 	}
+	vaultHashes := map[string]string{
+		"evt-1": "h1",
+		"evt-2": "h2",
+		"evt-3": "h3",
+	}
 
-	result, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-a")
+	result, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-a", vaultHashes)
 	if err != nil {
 		t.Fatalf("VerifyByLabelHash failed: %v", err)
 	}
@@ -198,8 +203,12 @@ func TestVerifyByLabelHash_TamperedEvent(t *testing.T) {
 			"evt-2": {Valid: false, ErrorDetail: "hash mismatch"},
 		},
 	}
+	vaultHashes := map[string]string{
+		"evt-1": "h1",
+		"evt-2": "h2",
+	}
 
-	result, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-a")
+	result, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-a", vaultHashes)
 	if err != nil {
 		t.Fatalf("VerifyByLabelHash failed: %v", err)
 	}
@@ -224,8 +233,11 @@ func TestVerifyByLabelHash_NoMatchingEvents(t *testing.T) {
 			"evt-1": {{ObjectID: "evt-1", HashValue: "h1", Metadata: map[string]interface{}{"label_hash": "hash-b", "timestamp": float64(1)}}},
 		},
 	}
+	vaultHashes := map[string]string{
+		"evt-1": "h1",
+	}
 
-	result, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-a")
+	result, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-a", vaultHashes)
 	if err != nil {
 		t.Fatalf("VerifyByLabelHash failed: %v", err)
 	}
@@ -257,9 +269,15 @@ func TestVerifyByLabelHash_MultipleCredentialsIndependent(t *testing.T) {
 			"evt-b2": {Valid: true},
 		},
 	}
+	vaultHashes := map[string]string{
+		"evt-a1": "ha1",
+		"evt-a2": "ha2",
+		"evt-b1": "hb1",
+		"evt-b2": "hb2",
+	}
 
 	// Verify hash-a (should show tampered)
-	resultA, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-a")
+	resultA, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-a", vaultHashes)
 	if err != nil {
 		t.Fatalf("VerifyByLabelHash for hash-a failed: %v", err)
 	}
@@ -271,7 +289,7 @@ func TestVerifyByLabelHash_MultipleCredentialsIndependent(t *testing.T) {
 	}
 
 	// Verify hash-b (should show clean, independent of hash-a's tampering)
-	resultB, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-b")
+	resultB, err := audit.VerifyByLabelHash(context.Background(), client, "entity", "hash-b", vaultHashes)
 	if err != nil {
 		t.Fatalf("VerifyByLabelHash for hash-b failed: %v", err)
 	}
@@ -285,5 +303,36 @@ func TestVerifyByLabelHash_MultipleCredentialsIndependent(t *testing.T) {
 	// Key assertion: tampering in hash-a does NOT affect hash-b
 	if resultA.Valid == resultB.Valid {
 		t.Error("per-credential verification broken: hash-a and hash-b should have different results")
+	}
+}
+
+func TestVerifyAll_SkipsPreExistingEvents(t *testing.T) {
+	// 3 events in collection, only 2 in vaultHashes — 1 should be skipped.
+	client := &mockClient{
+		collectionGet: map[string][]string{
+			audit.CollectionID("entity"): {"evt-1", "evt-2", "evt-3"},
+		},
+		validate: map[string]*audit.ValidationResult{
+			"evt-1": {Valid: true},
+			"evt-2": {Valid: true},
+		},
+	}
+	vaultHashes := map[string]string{
+		"evt-1": "hash1",
+		"evt-2": "hash2",
+		// evt-3 missing — pre-existing event
+	}
+	result, err := audit.VerifyAll(context.Background(), client, "entity", vaultHashes)
+	if err != nil {
+		t.Fatalf("VerifyAll failed: %v", err)
+	}
+	if result.EventCount != 2 {
+		t.Errorf("expected EventCount=2, got %d", result.EventCount)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("expected Skipped=1, got %d", result.Skipped)
+	}
+	if !result.Valid {
+		t.Error("expected Valid=true")
 	}
 }

--- a/internal/audit/queue.go
+++ b/internal/audit/queue.go
@@ -24,7 +24,7 @@ var ErrFlushFailed = errors.New("flush submission failed")
 // EventBuilder in Plan 03 (the gRPC client), allowing Queue to remain decoupled
 // from the network layer.
 type Submitter interface {
-	Submit(ctx context.Context, entry QueueEntry) error
+	Submit(ctx context.Context, entry QueueEntry) (string, error)
 }
 
 // QueueEntry is the unit of storage in the offline queue. On disk, only
@@ -272,7 +272,7 @@ func (q *Queue) Save(path string) error {
 // unchanged. On full success, the entries slice is cleared (Len returns 0).
 func (q *Queue) Flush(ctx context.Context, client Submitter) error {
 	for _, entry := range q.entries {
-		if err := client.Submit(ctx, entry); err != nil {
+		if _, err := client.Submit(ctx, entry); err != nil {
 			return fmt.Errorf("submitting queue entry: %w", err)
 		}
 	}

--- a/internal/audit/queue.go
+++ b/internal/audit/queue.go
@@ -270,10 +270,17 @@ func (q *Queue) Save(path string) error {
 // Flush calls client.Submit for each entry in append order. On the first
 // submission error, Flush stops and returns the error, leaving the queue
 // unchanged. On full success, the entries slice is cleared (Len returns 0).
-func (q *Queue) Flush(ctx context.Context, client Submitter) error {
+//
+// onHash, if non-nil, is called with (eventID, hashValue) for each successfully
+// submitted entry so callers can persist the hash for independent verification.
+func (q *Queue) Flush(ctx context.Context, client Submitter, onHash func(eventID, hashValue string)) error {
 	for _, entry := range q.entries {
-		if _, err := client.Submit(ctx, entry); err != nil {
+		hashValue, err := client.Submit(ctx, entry)
+		if err != nil {
 			return fmt.Errorf("submitting queue entry: %w", err)
+		}
+		if onHash != nil && hashValue != "" {
+			onHash(entry.Event.EventID, hashValue)
 		}
 	}
 	q.entries = q.entries[:0]

--- a/internal/audit/queue_test.go
+++ b/internal/audit/queue_test.go
@@ -33,12 +33,12 @@ type mockSubmitter struct {
 	retErr error
 }
 
-func (m *mockSubmitter) Submit(_ context.Context, entry audit.QueueEntry) error {
+func (m *mockSubmitter) Submit(_ context.Context, entry audit.QueueEntry) (string, error) {
 	m.calls = append(m.calls, entry)
 	if m.errOn > 0 && len(m.calls) == m.errOn {
-		return m.retErr
+		return "", m.retErr
 	}
-	return nil
+	return "fakehash", nil
 }
 
 func TestQueue_NewQueueEmpty(t *testing.T) {

--- a/internal/audit/queue_test.go
+++ b/internal/audit/queue_test.go
@@ -128,7 +128,7 @@ func TestQueue_Flush_SuccessCallsSubmitter(t *testing.T) {
 	_ = q.Append(makeEvent("hotp"))
 
 	mock := &mockSubmitter{}
-	if err := q.Flush(context.Background(), mock); err != nil {
+	if err := q.Flush(context.Background(), mock, nil); err != nil {
 		t.Fatalf("Flush returned error: %v", err)
 	}
 
@@ -146,7 +146,7 @@ func TestQueue_Flush_ErrorLeavesQueueUnchanged(t *testing.T) {
 	_ = q.Append(makeEvent("hotp"))
 
 	mock := &mockSubmitter{errOn: 1, retErr: audit.ErrFlushFailed}
-	err := q.Flush(context.Background(), mock)
+	err := q.Flush(context.Background(), mock, nil)
 	if err == nil {
 		t.Fatal("Flush should return error when submitter fails")
 	}
@@ -163,7 +163,7 @@ func TestQueue_Flush_OrderPreserved(t *testing.T) {
 	_ = q.Append(audit.NewAuthEvent("static", "third", "svc", "host", true, ""))
 
 	mock := &mockSubmitter{}
-	_ = q.Flush(context.Background(), mock)
+	_ = q.Flush(context.Background(), mock, nil)
 
 	if len(mock.calls) != 3 {
 		t.Fatalf("expected 3 calls, got %d", len(mock.calls))

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -807,6 +807,52 @@ func (m *Manager) VerifyRecoveryKey(recoveryRaw []byte) (bool, error) {
 	return hashHex == m.payload.RecoveryKeyHash, nil
 }
 
+// SetAuditHash stores an audit event hash in the vault for independent
+// verification. The vault is saved immediately after the update. If the
+// vault is locked, the hash is silently dropped (per D-14: vault write
+// failure is non-fatal).
+func (m *Manager) SetAuditHash(eventID, hashValue string) error {
+	if m.payload == nil {
+		return fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
+	}
+	if m.payload.AuditHashes == nil {
+		m.payload.AuditHashes = make(map[string]string)
+	}
+	m.payload.AuditHashes[eventID] = hashValue
+	err := m.Save()
+	// TODO(debug): remove before merge
+	if err == nil {
+		fmt.Fprintf(os.Stderr, "[debug] audit hash stored: eventID=%s hash=%.16s... total=%d\n",
+			eventID, hashValue, len(m.payload.AuditHashes))
+	} else {
+		fmt.Fprintf(os.Stderr, "[debug] audit hash store FAILED: eventID=%s err=%v\n", eventID, err)
+	}
+	return err
+}
+
+// AuditHashes returns a copy of the vault's audit hash map. The caller
+// is responsible for zeroing the returned map after use (D-16).
+// Returns nil if the vault is locked or no hashes exist.
+func (m *Manager) AuditHashes() map[string]string {
+	if m.payload == nil || m.payload.AuditHashes == nil {
+		return nil
+	}
+	cp := make(map[string]string, len(m.payload.AuditHashes))
+	for k, v := range m.payload.AuditHashes {
+		cp[k] = v
+	}
+	return cp
+}
+
+// ZeroAuditHashes overwrites all keys and values in a hash map with empty
+// strings to limit sensitive data lifetime in memory (D-16).
+func ZeroAuditHashes(m map[string]string) {
+	for k := range m {
+		m[k] = ""
+		delete(m, k)
+	}
+}
+
 // atomicWrite writes data to path using temp-file-rename for crash safety.
 func atomicWrite(path string, data []byte) error {
 	tmpPath := path + ".tmp"

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -527,15 +527,25 @@ func (m *Manager) saveLocked() error {
 	// Extract and validate the passphrase-wrapped DEK from the existing file
 	// before incrementing WriteCounter so that in-memory state stays consistent
 	// with what is on disk if we bail out here.
+	if len(oldData) < headerSize+4 {
+		return fmt.Errorf("vault file corrupt: too short to contain payload length: %w", errors.ErrVaultCorrupt)
+	}
 	oldPayloadLen := binary.BigEndian.Uint32(oldData[headerSize : headerSize+4])
 	oldAfterPayload := headerSize + 4 + int(oldPayloadLen)
+	if len(oldData) < oldAfterPayload+4 {
+		return fmt.Errorf("vault file corrupt: too short to contain wrapped DEK length: %w", errors.ErrVaultCorrupt)
+	}
 	oldWrappedDEKLen := binary.BigEndian.Uint32(oldData[oldAfterPayload : oldAfterPayload+4])
 	if oldWrappedDEKLen == 0 {
 		// The passphrase-wrapped DEK is missing from the on-disk file — this
 		// indicates prior corruption. Refuse to write and propagate the state.
 		return fmt.Errorf("vault file corrupt: passphrase-wrapped DEK is missing: %w", errors.ErrVaultCorrupt)
 	}
-	passphraseWrappedDEK := oldData[oldAfterPayload+4 : oldAfterPayload+4+int(oldWrappedDEKLen)]
+	dekEnd := oldAfterPayload + 4 + int(oldWrappedDEKLen)
+	if dekEnd > len(oldData) {
+		return fmt.Errorf("vault file corrupt: wrapped DEK extends past end of file: %w", errors.ErrVaultCorrupt)
+	}
+	passphraseWrappedDEK := oldData[oldAfterPayload+4 : dekEnd]
 
 	dekBuf, err := m.dek.Open()
 	if err != nil {
@@ -861,6 +871,8 @@ func (m *Manager) SetAuditHash(eventID, hashValue string) error {
 // is responsible for zeroing the returned map after use (D-16).
 // Returns nil if the vault is locked or no hashes exist.
 func (m *Manager) AuditHashes() map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.payload == nil || m.payload.AuditHashes == nil {
 		return nil
 	}

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -40,10 +41,11 @@ func zeroBytes(b []byte) {
 // payload before performing credential operations. Always defer Close to zero
 // sensitive memory.
 //
-// Concurrency: Manager assumes single-process access per vault file. Each CLI
-// invocation opens, operates, and closes the vault independently. No file
-// locking is performed; concurrent writers will corrupt the vault.
+// Concurrency: Manager is safe for concurrent use within a single process.
+// All mutating operations are serialized by mu. External file locking is not
+// performed; concurrent writers from separate processes will corrupt the vault.
 type Manager struct {
+	mu              sync.Mutex
 	path            string
 	header          *model.VaultHeader
 	payload         *model.VaultPayload
@@ -386,6 +388,8 @@ func (m *Manager) UnlockWithRecoveryKey(recoveryRaw []byte) error {
 
 // Close zeroes all sensitive memory held by the manager.
 func (m *Manager) Close() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.dek != nil {
 		m.dek.Destroy()
 		m.dek = nil
@@ -396,6 +400,8 @@ func (m *Manager) Close() {
 // AddCredential adds a credential to the vault and saves. Returns the assigned
 // credential ID.
 func (m *Manager) AddCredential(cred model.Credential) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.payload == nil {
 		return "", fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
 	}
@@ -413,7 +419,7 @@ func (m *Manager) AddCredential(cred model.Credential) (string, error) {
 	}
 	m.payload.Credentials = append(m.payload.Credentials, cred)
 	m.payload.ModifiedAt = now
-	if err := m.Save(); err != nil {
+	if err := m.saveLocked(); err != nil {
 		return "", err
 	}
 	return cred.ID, nil
@@ -421,6 +427,8 @@ func (m *Manager) AddCredential(cred model.Credential) (string, error) {
 
 // RemoveCredential removes a credential by ID and saves.
 func (m *Manager) RemoveCredential(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.payload == nil {
 		return fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
 	}
@@ -428,7 +436,7 @@ func (m *Manager) RemoveCredential(id string) error {
 		if c.ID == id {
 			m.payload.Credentials = append(m.payload.Credentials[:i], m.payload.Credentials[i+1:]...)
 			m.payload.ModifiedAt = time.Now().UTC()
-			return m.Save()
+			return m.saveLocked()
 		}
 	}
 	return fmt.Errorf("credential %q: %w", id, errors.ErrNotFound)
@@ -459,6 +467,8 @@ func (m *Manager) ListCredentials() []model.Credential {
 
 // UpdateCredential replaces the credential with the matching ID and saves.
 func (m *Manager) UpdateCredential(cred *model.Credential) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.payload == nil {
 		return fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
 	}
@@ -467,7 +477,7 @@ func (m *Manager) UpdateCredential(cred *model.Credential) error {
 			cred.ModifiedAt = time.Now().UTC()
 			m.payload.Credentials[i] = *cred
 			m.payload.ModifiedAt = cred.ModifiedAt
-			return m.Save()
+			return m.saveLocked()
 		}
 	}
 	return fmt.Errorf("credential %q: %w", cred.ID, errors.ErrNotFound)
@@ -489,6 +499,13 @@ func (m *Manager) Header() *model.VaultHeader {
 
 // Save re-encrypts and writes the vault to disk using temp-file-rename.
 func (m *Manager) Save() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.saveLocked()
+}
+
+// saveLocked is the internal Save implementation. Callers must hold m.mu.
+func (m *Manager) saveLocked() error {
 	if m.dek == nil || m.payload == nil {
 		return fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
 	}
@@ -525,6 +542,11 @@ func (m *Manager) Save() error {
 	oldPayloadLen := binary.BigEndian.Uint32(oldData[headerSize : headerSize+4])
 	oldAfterPayload := headerSize + 4 + int(oldPayloadLen)
 	oldWrappedDEKLen := binary.BigEndian.Uint32(oldData[oldAfterPayload : oldAfterPayload+4])
+	if oldWrappedDEKLen == 0 {
+		// The passphrase-wrapped DEK is missing from the on-disk file — this
+		// indicates prior corruption. Refuse to write and propagate the state.
+		return fmt.Errorf("vault file corrupt: passphrase-wrapped DEK is missing: %w", errors.ErrVaultCorrupt)
+	}
 	passphraseWrappedDEK := oldData[oldAfterPayload+4 : oldAfterPayload+4+int(oldWrappedDEKLen)]
 
 	headerBytes, err := Marshal(m.header)
@@ -713,6 +735,8 @@ func (m *Manager) ImportCredentials(data, importPassphrase []byte) (imported, sk
 // corrupt the payload, because the old file is preserved as a .bak until the
 // rename succeeds.
 func (m *Manager) ChangePassphrase(newPassphrase []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.dek == nil || m.payload == nil {
 		return fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
 	}
@@ -812,6 +836,8 @@ func (m *Manager) VerifyRecoveryKey(recoveryRaw []byte) (bool, error) {
 // vault is locked, the hash is silently dropped (per D-14: vault write
 // failure is non-fatal).
 func (m *Manager) SetAuditHash(eventID, hashValue string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.payload == nil {
 		return fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
 	}
@@ -819,15 +845,7 @@ func (m *Manager) SetAuditHash(eventID, hashValue string) error {
 		m.payload.AuditHashes = make(map[string]string)
 	}
 	m.payload.AuditHashes[eventID] = hashValue
-	err := m.Save()
-	// TODO(debug): remove before merge
-	if err == nil {
-		fmt.Fprintf(os.Stderr, "[debug] audit hash stored: eventID=%s hash=%.16s... total=%d\n",
-			eventID, hashValue, len(m.payload.AuditHashes))
-	} else {
-		fmt.Fprintf(os.Stderr, "[debug] audit hash store FAILED: eventID=%s err=%v\n", eventID, err)
-	}
-	return err
+	return m.saveLocked()
 }
 
 // AuditHashes returns a copy of the vault's audit hash map. The caller

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -41,9 +41,10 @@ func zeroBytes(b []byte) {
 // payload before performing credential operations. Always defer Close to zero
 // sensitive memory.
 //
-// Concurrency: Manager is safe for concurrent use within a single process.
-// All mutating operations are serialized by mu. External file locking is not
-// performed; concurrent writers from separate processes will corrupt the vault.
+// Concurrency: All mutating operations are serialized by mu. Read-only methods
+// (GetCredential, ListCredentials) are not protected and must not be called
+// concurrently with writes. External file locking is not performed; concurrent
+// writers from separate processes will corrupt the vault.
 type Manager struct {
 	mu              sync.Mutex
 	path            string

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -444,6 +444,7 @@ func (m *Manager) RemoveCredential(id string) error {
 }
 
 // GetCredential returns the credential matching the given label (case-insensitive).
+// Must not be called concurrently with any mutating operation.
 func (m *Manager) GetCredential(label string) (*model.Credential, error) {
 	if m.payload == nil {
 		return nil, fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
@@ -457,6 +458,7 @@ func (m *Manager) GetCredential(label string) (*model.Credential, error) {
 }
 
 // ListCredentials returns a copy of all credentials in the vault.
+// Must not be called concurrently with any mutating operation.
 func (m *Manager) ListCredentials() []model.Credential {
 	if m.payload == nil {
 		return nil
@@ -511,6 +513,27 @@ func (m *Manager) saveLocked() error {
 		return fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
 	}
 
+	// Read the existing file first to validate it before mutating any state.
+	// This preserves the passphrase-wrapped DEK, which only changes on
+	// passphrase change (we don't hold the derived key).
+	oldData, err := os.ReadFile(m.path)
+	if err != nil {
+		return fmt.Errorf("reading vault for save: %w", err)
+	}
+
+	// Extract and validate the passphrase-wrapped DEK from the existing file
+	// before incrementing WriteCounter so that in-memory state stays consistent
+	// with what is on disk if we bail out here.
+	oldPayloadLen := binary.BigEndian.Uint32(oldData[headerSize : headerSize+4])
+	oldAfterPayload := headerSize + 4 + int(oldPayloadLen)
+	oldWrappedDEKLen := binary.BigEndian.Uint32(oldData[oldAfterPayload : oldAfterPayload+4])
+	if oldWrappedDEKLen == 0 {
+		// The passphrase-wrapped DEK is missing from the on-disk file — this
+		// indicates prior corruption. Refuse to write and propagate the state.
+		return fmt.Errorf("vault file corrupt: passphrase-wrapped DEK is missing: %w", errors.ErrVaultCorrupt)
+	}
+	passphraseWrappedDEK := oldData[oldAfterPayload+4 : oldAfterPayload+4+int(oldWrappedDEKLen)]
+
 	dekBuf, err := m.dek.Open()
 	if err != nil {
 		return fmt.Errorf("opening DEK: %w", err)
@@ -531,24 +554,6 @@ func (m *Manager) saveLocked() error {
 	if err != nil {
 		return fmt.Errorf("encrypting payload: %w", err)
 	}
-
-	// Read the existing file to preserve the passphrase-wrapped DEK, which
-	// only changes on passphrase change (we don't hold the derived key).
-	oldData, err := os.ReadFile(m.path)
-	if err != nil {
-		return fmt.Errorf("reading vault for save: %w", err)
-	}
-
-	// Extract the passphrase-wrapped DEK from the existing file.
-	oldPayloadLen := binary.BigEndian.Uint32(oldData[headerSize : headerSize+4])
-	oldAfterPayload := headerSize + 4 + int(oldPayloadLen)
-	oldWrappedDEKLen := binary.BigEndian.Uint32(oldData[oldAfterPayload : oldAfterPayload+4])
-	if oldWrappedDEKLen == 0 {
-		// The passphrase-wrapped DEK is missing from the on-disk file — this
-		// indicates prior corruption. Refuse to write and propagate the state.
-		return fmt.Errorf("vault file corrupt: passphrase-wrapped DEK is missing: %w", errors.ErrVaultCorrupt)
-	}
-	passphraseWrappedDEK := oldData[oldAfterPayload+4 : oldAfterPayload+4+int(oldWrappedDEKLen)]
 
 	headerBytes, err := Marshal(m.header)
 	if err != nil {

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -395,6 +395,9 @@ func (m *Manager) Close() {
 		m.dek.Destroy()
 		m.dek = nil
 	}
+	if m.payload != nil {
+		ZeroAuditHashes(m.payload.AuditHashes)
+	}
 	m.payload = nil
 }
 

--- a/internal/vault/manager_test.go
+++ b/internal/vault/manager_test.go
@@ -1159,3 +1159,122 @@ func TestOpenWithTamperedArgonParameters(t *testing.T) {
 		})
 	}
 }
+
+// TestImportAllSkipped_VaultStillUnlockable reproduces the reported bug:
+// importing a .enc file when all credentials already exist (all skipped)
+// must not corrupt the vault. The vault must remain unlockable after
+// Close() and re-Open().
+func TestImportAllSkipped_VaultStillUnlockable(t *testing.T) {
+	passphrase := []byte("test-passphrase")
+	exportPass := []byte("export-passphrase-1234")
+
+	// 1. Create vault and add a credential.
+	path, _ := createTestVault(t)
+	m, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := m.Unlock(passphrase); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if _, err := m.AddCredential(model.Credential{
+		Label: "github", Type: model.CredentialTOTP, Secret: "JBSWY3DPEHPK3PXP",
+	}); err != nil {
+		t.Fatalf("AddCredential: %v", err)
+	}
+
+	// 2. Export credentials.
+	enc, err := m.ExportCredentials(exportPass)
+	if err != nil {
+		t.Fatalf("ExportCredentials: %v", err)
+	}
+
+	// 3. Import the same .enc (all credentials already exist → all skipped).
+	imported, skipped, err := m.ImportCredentials(enc, exportPass)
+	if err != nil {
+		t.Fatalf("ImportCredentials: %v", err)
+	}
+	if imported != 0 || skipped != 1 {
+		t.Fatalf("expected 0 imported, 1 skipped; got imported=%d skipped=%d", imported, skipped)
+	}
+
+	// 4. Close (simulates app shutdown).
+	m.Close()
+
+	// 5. Re-open and unlock (simulates app restart).
+	m2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Re-Open: %v", err)
+	}
+	defer m2.Close()
+	if err := m2.Unlock(passphrase); err != nil {
+		t.Fatalf("Unlock after import-all-skipped: %v (vault corrupted)", err)
+	}
+}
+
+// TestImportSomeSkipped_VaultStillUnlockable is the same as above but with
+// a mix of new and duplicate credentials (partial import).
+func TestImportSomeSkipped_VaultStillUnlockable(t *testing.T) {
+	passphrase := []byte("test-passphrase")
+	exportPass := []byte("export-passphrase-1234")
+
+	// 1. Create vault with one credential.
+	path, _ := createTestVault(t)
+	m, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := m.Unlock(passphrase); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if _, err := m.AddCredential(model.Credential{
+		Label: "github", Type: model.CredentialTOTP, Secret: "JBSWY3DPEHPK3PXP",
+	}); err != nil {
+		t.Fatalf("AddCredential: %v", err)
+	}
+
+	// 2. Build export with github (duplicate) + gitlab (new).
+	srcPath, _ := createTestVault(t)
+	src, err := Open(srcPath)
+	if err != nil {
+		t.Fatalf("Open src: %v", err)
+	}
+	if err := src.Unlock(passphrase); err != nil {
+		t.Fatalf("Unlock src: %v", err)
+	}
+	if _, err := src.AddCredential(model.Credential{
+		Label: "github", Type: model.CredentialTOTP, Secret: "JBSWY3DPEHPK3PXP",
+	}); err != nil {
+		t.Fatalf("AddCredential github src: %v", err)
+	}
+	if _, err := src.AddCredential(model.Credential{
+		Label: "gitlab", Type: model.CredentialTOTP, Secret: "JBSWY3DPEHPK3PXP",
+	}); err != nil {
+		t.Fatalf("AddCredential gitlab src: %v", err)
+	}
+	enc, err := src.ExportCredentials(exportPass)
+	if err != nil {
+		t.Fatalf("ExportCredentials: %v", err)
+	}
+	src.Close()
+
+	// 3. Import (github skipped, gitlab added → Save() called once).
+	imported, skipped, err := m.ImportCredentials(enc, exportPass)
+	if err != nil {
+		t.Fatalf("ImportCredentials: %v", err)
+	}
+	if imported != 1 || skipped != 1 {
+		t.Fatalf("expected 1 imported, 1 skipped; got imported=%d skipped=%d", imported, skipped)
+	}
+
+	// 4. Close and re-open.
+	m.Close()
+	m2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Re-Open: %v", err)
+	}
+	defer m2.Close()
+	if err := m2.Unlock(passphrase); err != nil {
+		t.Fatalf("Unlock after partial import: %v (vault corrupted)", err)
+	}
+}

--- a/pkg/model/vault.go
+++ b/pkg/model/vault.go
@@ -55,7 +55,8 @@ type VaultPayload struct {
 	ModifiedAt      time.Time    `json:"modified_at"`
 	Credentials     []Credential `json:"credentials"`
 	RecoveryKeyHash string       `json:"recovery_key_hash"`
-	VaultID         string       `json:"vault_id,omitempty"`
+	VaultID         string            `json:"vault_id,omitempty"`
+	AuditHashes     map[string]string `json:"audit_hashes,omitempty"`
 }
 
 // VaultHeader represents the plaintext header of a vault file as specified in


### PR DESCRIPTION
## Summary

This PR fixes the circular validation bug in audit integrity verification and extends it to detect metadata field tampering.

## Related issues or PRs

- Resolves #67
- #75

## Changes made

- Replace circular `Validate` flow (fetch-then-validate same values) with vault-hash-based independent verification
- Store full event JSON as `"content"` in ScalarDL metadata at submit time
- Add three-check validation: (1) stored hash_value vs vault hash, (2) SHA-256(content) vs vault hash, (3) individual metadata display fields vs authenticated content
- Add `SetAuditHash`/`AuditHashes`/`ZeroAuditHashes` to vault manager for independent hash storage
- Wire `OnHashStored` callback across CLI, TUI, and GUI so vault hashes are recorded at submit time
- Align tamper detection messaging across CLI, TUI, and GUI: "TAMPERING DETECTED" with plain-language per-event fault descriptions
- Add `reportedError` wrapper in CLI to control output order (header before detail)

## Technical implementation

- **Approach:** Vault stores `{eventID → SHA-256(event_json)}` at submit time. Validate fetches the record via `Get`, then checks hash_value against vault (Check 1), recomputes SHA-256(content) against vault (Check 2), and cross-checks display fields against authenticated content (Check 3). Check 3 catches the attack where only a display field like `operation` is changed while `hash_value` and `content` are left intact.
- **Key components modified:** `internal/audit/client.go`, `internal/audit/builder.go`, `internal/vault/manager.go`, `pkg/model/vault.go`, `cmd/tegata/verify.go`, `cmd/tegata/tui_model.go`, `cmd/tegata-gui/app.go`, `AuditPanel.tsx`
- **Dependencies added/removed:** None
- **Design patterns used:** Vault as independent tamper-evident reference; `callSafe` helper for best-effort panic recovery in callbacks

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [ ] Builds successfully on Windows (amd64) not applicable – macOS-only development environment
- [ ] Builds successfully on Linux (amd64) not applicable – macOS-only development environment
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] CLI commands tested manually with expected inputs
- [x] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable)
- [x] ScalarDL integration tested (if applicable) – live end-to-end tampering verified: hash_value manipulation, content replacement, and metadata field changes (operation "hotp" → "totp") all detected correctly
- [ ] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data – `ZeroAuditHashes` called on vault close and after verify operations
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information – fault messages use hashed IDs and operation types only, no raw secrets
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable) not applicable – internal implementation change with no user-facing API or config changes

## Breaking changes

- [x] No breaking changes

## Additional context

Pre-existing audit events (submitted before this fix) have no `content` field in their ScalarDL metadata and no entry in the vault hash store. These events are skipped during verification with a counter (`Skipped`). Only events submitted with the fixed binary are subject to all three checks.

**Note for user docs:** `tegata verify` enforces three tamper-detection checks (hash_value mismatch, content hash mismatch, metadata field inconsistency). A fourth guard — `len(records) > 1` to detect replay attacks — is currently unreachable in practice. The `object.v1_0_0.Get` contract registered by `scalardl-hashstore bootstrap` is sourced from `generic-contracts` (the hash-store module registers that class directly; it ships no separate implementation). That contract calls `ledger.get()`, which returns `Optional<Asset>` — at most one record — so multiple versions can never surface to the caller. The guard is retained for defensive correctness in case a future ScalarDL contract version exposes multi-version retrieval. See 849b42f for the full reasoning in code.