### PR TITLE
Add Docker integration tests for tampering detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
   integration-tests:
     name: Integration tests (Docker)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: [build-and-test]
     steps:
       - name: Checkout code
@@ -90,4 +90,4 @@ jobs:
         run: docker info
 
       - name: Run Docker integration tests
-        run: go test -tags integration ./internal/audit/... -v -timeout 10m
+        run: go test -tags integration ./internal/audit/... -v -timeout 20m

--- a/internal/audit/client.go
+++ b/internal/audit/client.go
@@ -544,6 +544,15 @@ func (c *LedgerClient) Validate(ctx context.Context, objectID, expectedHash stri
 	}
 	// Each event uses a UUID EventID written exactly once, so len > 1 is
 	// unexpected and is itself evidence of tampering or a replay.
+	//
+	// NOTE: With the current ScalarDL HashStore SDK (v3.13+), this branch is
+	// unreachable in practice. The object.v1_0_0.Get contract is implemented in
+	// generic-contracts and calls ledger.get(), which returns Optional<Asset> —
+	// at most one record. The HashStore bootstrap registers the same generic
+	// contract class directly (hash-store depends on generic-contracts; it ships
+	// no separate Get implementation). If ScalarDL ever exposes a contract that
+	// returns multiple versions (e.g. via ledger.scan()), this guard would
+	// become active. Keep it for defensive correctness and to signal intent.
 	if len(records) > 1 {
 		return &ValidationResult{
 			Valid:       false,

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -296,7 +296,9 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// All callers issue UPDATE statements targeting a single row. runSQL asserts
 	// that psql reports "UPDATE 1" so that a silent zero-row update (e.g. due to
 	// a wrong object ID prefix) fails immediately with a clear message rather
-	// than letting assertTampering fail with a confusing Valid=true.
+	// than letting assertTampering fail with a confusing Valid=true. The id value
+	// interpolated into each SQL string is always a UUID from evt.EventID (hex
+	// digits and hyphens only), so fmt.Sprintf is safe here.
 	runSQL := func(t *testing.T, sql string) {
 		t.Helper()
 		out, err := exec.Command(

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -288,6 +289,11 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// container via docker exec. The container name is always
 	// tegata-ledger-postgres-1 because the compose project name is fixed to
 	// "tegata-ledger" in docker-compose.yml.
+	//
+	// All callers issue UPDATE statements targeting a single row. runSQL asserts
+	// that psql reports "UPDATE 1" so that a silent zero-row update (e.g. due to
+	// a wrong object ID prefix) fails immediately with a clear message rather
+	// than letting assertTampering fail with a confusing Valid=true.
 	runSQL := func(t *testing.T, sql string) {
 		t.Helper()
 		out, err := exec.Command(
@@ -296,6 +302,16 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 		).CombinedOutput()
 		if err != nil {
 			t.Fatalf("psql: %v\n%s", err, out)
+		}
+		found := false
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.TrimSpace(line) == "UPDATE 1" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("psql UPDATE affected != 1 row; verify the \"o_\" object ID prefix convention\n%s", out)
 		}
 	}
 
@@ -349,6 +365,7 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// Check 1: hash_value in the stored output replaced with a different value.
 	t.Run("HashValueTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
+		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline: fresh event must be valid
@@ -364,6 +381,7 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// matches hash_value even though hash_value itself is untouched.
 	t.Run("ContentTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
+		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline
@@ -379,6 +397,7 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// left intact, testing the cross-field consistency check.
 	t.Run("OperationFieldTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
+		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline
@@ -394,6 +413,7 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// left intact, testing the cross-field consistency check.
 	t.Run("LabelHashTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
+		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -244,3 +244,164 @@ func TestIntegration_StopStack_NonExistentCompose(t *testing.T) {
 	// Docker compose should fail with a file-not-found or similar error.
 	t.Logf("StopStack_NonExistentCompose verified: returned expected error: %v", err)
 }
+
+// TestIntegration_TamperingDetection spins up a full Docker stack, submits
+// real audit events via the production Submit path, then directly manipulates
+// the ScalarDL PostgreSQL database to simulate an attacker bypassing the gRPC
+// contracts. It asserts that client.Validate detects each of the four
+// supported tampering scenarios:
+//
+//   - Check 1: hash_value replaced — "record hash has been altered"
+//   - Check 2: content replaced — "event content has been altered"
+//   - Check 3a: metadata.operation changed — "event type field has been altered"
+//   - Check 3b: metadata.label_hash changed — "credential field has been altered"
+//
+// Each subtest submits its own fresh event so subtests are fully independent.
+// The replay-attack guard (len(records) > 1) is not covered here because the
+// object.v1_0_0.Get contract always returns a single record regardless of how
+// many rows exist in scalar.asset — see the comment in client.go Validate and
+// commit 849b42f for the full reasoning.
+func TestIntegration_TamperingDetection(t *testing.T) {
+	requireDocker(t)
+
+	srcDir, err := composeSourceDir()
+	if err != nil {
+		t.Fatalf("determining compose source directory: %v", err)
+	}
+	composeWorkDir := t.TempDir()
+	fsys := os.DirFS(srcDir)
+
+	cfg, err := audit.SetupStack(fsys, composeWorkDir, "test-vault-tampering", nil, nil)
+	if err != nil {
+		t.Fatalf("SetupStack: %v", err)
+	}
+	composePath := filepath.Join(composeWorkDir, "docker-compose.yml")
+	t.Cleanup(func() { _ = audit.TeardownStack(composePath) })
+
+	client, err := audit.NewClientFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("creating ledger client: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	// runSQL executes a SQL statement directly in the ScalarDL PostgreSQL
+	// container via docker exec. The container name is always
+	// tegata-ledger-postgres-1 because the compose project name is fixed to
+	// "tegata-ledger" in docker-compose.yml.
+	runSQL := func(t *testing.T, sql string) {
+		t.Helper()
+		out, err := exec.Command(
+			"docker", "exec", "tegata-ledger-postgres-1",
+			"psql", "-U", "scalardl", "-d", "scalardl", "-c", sql,
+		).CombinedOutput()
+		if err != nil {
+			t.Fatalf("psql: %v\n%s", err, out)
+		}
+	}
+
+	// submitEvent submits a fresh signed event via the production Submit path
+	// and returns its objectID and the vault hash value.
+	submitEvent := func(t *testing.T, opType string) (objectID, hashValue string) {
+		t.Helper()
+		evt := audit.NewAuthEvent(opType, "test-label", "test-service", "test-host", true, "")
+		entry := audit.QueueEntry{Event: evt}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		hash, err := client.Submit(ctx, entry)
+		if err != nil {
+			t.Fatalf("Submit(%s): %v", opType, err)
+		}
+		return evt.EventID, hash
+	}
+
+	// assertTampering calls Validate and asserts Valid=false with the expected
+	// ErrorDetail message.
+	assertTampering := func(t *testing.T, objectID, hashValue, wantDetail string) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		result, err := client.Validate(ctx, objectID, hashValue)
+		if err != nil {
+			t.Fatalf("Validate: unexpected error: %v", err)
+		}
+		if result.Valid {
+			t.Error("Validate: expected Valid=false after tampering, got Valid=true")
+		}
+		if result.ErrorDetail != wantDetail {
+			t.Errorf("Validate ErrorDetail = %q, want %q", result.ErrorDetail, wantDetail)
+		}
+	}
+
+	// assertClean calls Validate and asserts Valid=true.
+	assertClean := func(t *testing.T, objectID, hashValue string) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		result, err := client.Validate(ctx, objectID, hashValue)
+		if err != nil {
+			t.Fatalf("Validate: unexpected error: %v", err)
+		}
+		if !result.Valid {
+			t.Errorf("Validate: expected Valid=true, got Valid=false: %s", result.ErrorDetail)
+		}
+	}
+
+	// Check 1: hash_value in the stored output replaced with a different value.
+	t.Run("HashValueTampered", func(t *testing.T) {
+		objectID, hashValue := submitEvent(t, "totp")
+		dbID := "o_" + objectID
+
+		assertClean(t, objectID, hashValue) // baseline: fresh event must be valid
+
+		runSQL(t, fmt.Sprintf(
+			`UPDATE scalar.asset SET output = jsonb_set(output::jsonb, '{hash_value}', '"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"')::text WHERE id = '%s';`,
+			dbID,
+		))
+		assertTampering(t, objectID, hashValue, "record hash has been altered")
+	})
+
+	// Check 2: metadata.content replaced, so SHA-256(content) no longer
+	// matches hash_value even though hash_value itself is untouched.
+	t.Run("ContentTampered", func(t *testing.T) {
+		objectID, hashValue := submitEvent(t, "totp")
+		dbID := "o_" + objectID
+
+		assertClean(t, objectID, hashValue) // baseline
+
+		runSQL(t, fmt.Sprintf(
+			`UPDATE scalar.asset SET output = jsonb_set(output::jsonb, '{metadata,content}', to_jsonb((output::jsonb->'metadata'->>'content') || 'X'))::text WHERE id = '%s';`,
+			dbID,
+		))
+		assertTampering(t, objectID, hashValue, "event content has been altered")
+	})
+
+	// Check 3a: metadata.operation changed while hash_value and content are
+	// left intact, testing the cross-field consistency check.
+	t.Run("OperationFieldTampered", func(t *testing.T) {
+		objectID, hashValue := submitEvent(t, "totp")
+		dbID := "o_" + objectID
+
+		assertClean(t, objectID, hashValue) // baseline
+
+		runSQL(t, fmt.Sprintf(
+			`UPDATE scalar.asset SET output = jsonb_set(output::jsonb, '{metadata,operation}', '"hotp"')::text WHERE id = '%s';`,
+			dbID,
+		))
+		assertTampering(t, objectID, hashValue, "event type field has been altered")
+	})
+
+	// Check 3b: metadata.label_hash zeroed while hash_value and content are
+	// left intact, testing the cross-field consistency check.
+	t.Run("LabelHashTampered", func(t *testing.T) {
+		objectID, hashValue := submitEvent(t, "totp")
+		dbID := "o_" + objectID
+
+		assertClean(t, objectID, hashValue) // baseline
+
+		runSQL(t, fmt.Sprintf(
+			`UPDATE scalar.asset SET output = jsonb_set(output::jsonb, '{metadata,label_hash}', '"0000000000000000000000000000000000000000000000000000000000000000"')::text WHERE id = '%s';`,
+			dbID,
+		))
+		assertTampering(t, objectID, hashValue, "credential field has been altered")
+	})
+}

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -258,6 +258,8 @@ func TestIntegration_StopStack_NonExistentCompose(t *testing.T) {
 //   - Check 3b: metadata.label_hash changed — "credential field has been altered"
 //
 // Each subtest submits its own fresh event so subtests are fully independent.
+// ScalarDL stores object IDs in scalar.asset with an "o_" prefix, so each
+// subtest constructs dbID = "o_" + objectID when targeting the database row.
 // The replay-attack guard (len(records) > 1) is not covered here because the
 // object.v1_0_0.Get contract always returns a single record regardless of how
 // many rows exist in scalar.asset — see the comment in client.go Validate and
@@ -288,7 +290,8 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// runSQL executes a SQL statement directly in the ScalarDL PostgreSQL
 	// container via docker exec. The container name is always
 	// tegata-ledger-postgres-1 because the compose project name is fixed to
-	// "tegata-ledger" in docker-compose.yml.
+	// "tegata-ledger" in docker-compose.yml (see the `name:` field at the top
+	// of that file). If the compose project name changes, update this string.
 	//
 	// All callers issue UPDATE statements targeting a single row. runSQL asserts
 	// that psql reports "UPDATE 1" so that a silent zero-row update (e.g. due to
@@ -348,7 +351,9 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 		}
 	}
 
-	// assertClean calls Validate and asserts Valid=true.
+	// assertClean calls Validate and asserts Valid=true. Uses t.Fatalf so a
+	// baseline failure stops the subtest immediately rather than letting the
+	// subsequent mutation run and produce a misleading second failure.
 	assertClean := func(t *testing.T, objectID, hashValue string) {
 		t.Helper()
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -358,14 +363,13 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 			t.Fatalf("Validate: unexpected error: %v", err)
 		}
 		if !result.Valid {
-			t.Errorf("Validate: expected Valid=true, got Valid=false: %s", result.ErrorDetail)
+			t.Fatalf("Validate: expected Valid=true, got Valid=false: %s", result.ErrorDetail)
 		}
 	}
 
 	// Check 1: hash_value in the stored output replaced with a different value.
 	t.Run("HashValueTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
-		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline: fresh event must be valid
@@ -381,7 +385,6 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// matches hash_value even though hash_value itself is untouched.
 	t.Run("ContentTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
-		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline
@@ -397,7 +400,6 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// left intact, testing the cross-field consistency check.
 	t.Run("OperationFieldTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
-		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline
@@ -413,7 +415,6 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// left intact, testing the cross-field consistency check.
 	t.Run("LabelHashTampered", func(t *testing.T) {
 		objectID, hashValue := submitEvent(t, "totp")
-		// ScalarDL stores object IDs in scalar.asset with an "o_" prefix.
 		dbID := "o_" + objectID
 
 		assertClean(t, objectID, hashValue) // baseline


### PR DESCRIPTION
## Summary

This PR adds automated integration tests that verify `client.Validate` correctly detects all four supported tampering scenarios against a live ScalarDL + PostgreSQL stack.

## Related issues or PRs

- Builds on #74

## Changes made

- Add `TestIntegration_TamperingDetection` to `internal/audit/docker_integration_test.go` with four subtests covering each enforced check
- Bump CI `integration-tests` job timeout from 15 to 25 minutes and Go test timeout from 10m to 20m to accommodate three sequential `SetupStack` calls

## Technical implementation

- **Approach:** Each subtest submits a real event via the production `Submit` path to get a live record in ScalarDL, then directly manipulates the `scalar.asset` table via `docker exec psql` to simulate an attacker bypassing the gRPC contracts, then calls `client.Validate` and asserts the expected `ErrorDetail`. Each subtest uses its own fresh event so subtests are fully independent — no restore logic needed.
- **Key components modified:** `internal/audit/docker_integration_test.go`, `.github/workflows/ci.yml`
- **Dependencies added/removed:** None
- **Design patterns used:** Shared stack setup with isolated per-subtest events; `t.Run` subtests for clear failure attribution

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [ ] Builds successfully on Windows (amd64) not applicable – Docker integration tests only run on Linux in CI
- [ ] Builds successfully on Linux (amd64) not applicable – macOS-only development environment
- [x] Unit tests pass
- [x] Integration tests pass (if applicable) – all four subtests pass locally against the running ScalarDL stack (30s total, reusing already-running containers)
- [ ] CLI commands tested manually with expected inputs not applicable – test-only change
- [ ] Edge cases and error handling tested (invalid inputs, missing files, permission errors) not applicable – test-only change
- [ ] Cryptographic operations verified (if applicable) not applicable
- [x] ScalarDL integration tested (if applicable) – live run confirmed all four subtests pass
- [ ] Cross-platform compatibility verified (if applicable) not applicable – Docker integration tests run on Linux only

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries not applicable – test-only change
- [x] Memory is zeroed after handling sensitive data not applicable – test-only change
- [x] Input validation implemented for all user-provided data not applicable – test-only change
- [x] No SQL injection, command injection, or path traversal vulnerabilities – SQL values are controlled test constants, not user input
- [x] Error messages don't leak sensitive information not applicable – test-only change
- [x] Vault files remain encrypted and properly protected not applicable – test-only change
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable) not applicable

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic – comment explains why the replay-attack guard is excluded, with reference to commit 849b42f
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable) not applicable – test-only change

## Breaking changes

- [x] No breaking changes

## Additional context

The replay-attack guard (`len(records) > 1` in `Validate`) is intentionally not covered — the `object.v1_0_0.Get` contract always returns a single record regardless of how many rows exist in `scalar.asset`. See commit 849b42f and the code comment for the full explanation.

The CI timeout bump is required because `TestIntegration_TamperingDetection` is the third test in the suite to call `SetupStack`, and contract registration can take up to 5 minutes per call on a cold runner.