### PR TITLE
Fix TestWizardLocalVaultWarning test failure by using temporary directories

### DIFF
--- a/cmd/tegata/tui_model_test.go
+++ b/cmd/tegata/tui_model_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -232,12 +233,15 @@ func TestWizardRecoveryKeyBlocksDuringCreation(t *testing.T) {
 // TestWizardLocalVaultWarning asserts that choosing a non-removable path shows
 // the local-drive advisory on the first Enter and advances on the second Enter.
 func TestWizardLocalVaultWarning(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "test-vault")
+
 	m := initialModel("")
 	// Type a path that is definitely not on a removable drive.
-	m = typeInto(m, "/tmp/test-vault")
+	m = typeInto(m, vaultPath)
 	// First Enter: advisory should be shown; state stays at welcome.
 	m = sendKey(m, "enter")
-	if !isRemovablePath("/tmp/test-vault") {
+	if !isRemovablePath(vaultPath) {
 		// Non-removable: expect the warning state.
 		if m.state != stateWizardWelcome {
 			t.Errorf("expected stateWizardWelcome after first Enter on non-removable path, got %v", m.state)
@@ -264,11 +268,14 @@ func TestWizardLocalVaultWarning(t *testing.T) {
 // TestWizardLocalVaultWarningClearsOnEdit asserts that editing the path after
 // the advisory clears the warning so a fresh check runs on the next Enter.
 func TestWizardLocalVaultWarningClearsOnEdit(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "test-vault")
+
 	m := initialModel("")
-	m = typeInto(m, "/tmp/test-vault")
+	m = typeInto(m, vaultPath)
 	m = sendKey(m, "enter") // trigger advisory (if non-removable)
 	if !m.localVaultWarn {
-		t.Skip("skipping: /tmp is removable on this system")
+		t.Skip("skipping: path is removable on this system")
 	}
 	// Typing clears the advisory.
 	m = typeInto(m, "x")


### PR DESCRIPTION
## Summary

This PR fixes the `TestWizardLocalVaultWarning` test failure by using `t.TempDir()` for isolated test directories instead of relying on a hardcoded `/tmp/test-vault` path that persisted between test runs.

## Related issues or PRs

Resolves #77

## Changes made

- Updated `TestWizardLocalVaultWarning` to use `t.TempDir()` for creating isolated test directories
- Updated `TestWizardLocalVaultWarningClearsOnEdit` to use `t.TempDir()` for consistency
- Added `"path/filepath"` import to support the changes
- Cleaned up leftover test artifacts from previous test runs

## Technical implementation

- **Approach:** Replaced hardcoded test paths with Go's `t.TempDir()` to create temporary directories unique to each test run
- **Key components modified:** `cmd/tegata/tui_model_test.go`
- **Dependencies added/removed:** None (added import only)
- **Design patterns used:** Go's built-in test temporary directory pattern for test isolation

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [x] Builds successfully on Windows (amd64)
- [ ] Builds successfully on Linux (amd64)
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable) – not applicable, test fix only
- [ ] CLI commands tested manually with expected inputs – not applicable, test fix only
- [ ] Edge cases and error handling tested (invalid inputs, missing files, permission errors) – not applicable, test fix only
- [ ] Cryptographic operations verified (if applicable) – not applicable, test fix only
- [ ] ScalarDL integration tested (if applicable) – not applicable, test fix only
- [ ] Cross-platform compatibility verified (if applicable) – not applicable, test fix only

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [ ] Cryptographic operations use secure, well-tested libraries – not applicable, test fix only
- [ ] Memory is zeroed after handling sensitive data – not applicable, test fix only
- [ ] Input validation implemented for all user-provided data – not applicable, test fix only
- [ ] No SQL injection, command injection, or path traversal vulnerabilities – not applicable, test fix only
- [ ] Error messages don't leak sensitive information – not applicable, test fix only
- [ ] Vault files remain encrypted and properly protected – not applicable, test fix only
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable) – not applicable, test fix only

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [ ] Added appropriate comments for complex cryptographic or security logic – not applicable, test fix only
- [x] No hardcoded secrets or configuration values
- [ ] Proper error handling and user-friendly error messages – not applicable, test fix only
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable) – not applicable, test fix only

## Breaking changes

- [x] No breaking changes

## Additional context

The root cause was that the test used a hardcoded `/tmp/test-vault` path that persisted between test runs. On subsequent test runs, the code would find an existing vault file at `/tmp/test-vault/vault.tegata` and transition to the unlock state instead of showing the local vault warning. Using `t.TempDir()` ensures test isolation and prevents state pollution between runs.