### PR TITLE
Expand audit logging to vault lifecycle and credential management operations

### DIFF
--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -823,7 +823,7 @@ func (a *App) GetAuditHistory() ([]AuditHistoryRecord, error) {
 	for i, r := range result.Records {
 		records[i] = AuditHistoryRecord{
 			ObjectID:  r.ObjectID,
-			Operation: r.Operation,
+			Operation: audit.FormatOperation(r.Operation),
 			LabelHash: r.LabelHash,
 			Timestamp: r.Timestamp,
 			HashValue: r.HashValue,

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -773,6 +773,7 @@ func (a *App) buildEventBuilder(cfg config.Config, vaultPath string, passphrase 
 type AuditHistoryRecord struct {
 	ObjectID  string `json:"object_id"`
 	Operation string `json:"operation"`
+	Label     string `json:"label"`
 	LabelHash string `json:"label_hash"`
 	Timestamp int64  `json:"timestamp"`
 	HashValue string `json:"hash_value"`
@@ -819,11 +820,21 @@ func (a *App) GetAuditHistory() ([]AuditHistoryRecord, error) {
 		_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: %s\n", result.Warning)
 	}
 
+	// Build label maps for hash resolution — same approach as TUI/CLI history.
+	creds := a.vault.ListCredentials()
+	labelNames := make([]string, len(creds))
+	for i, c := range creds {
+		labelNames[i] = c.Label
+	}
+	labelMap := audit.BuildLabelMap(labelNames)
+	deletedMap := a.vault.DeletedLabels()
+
 	records := make([]AuditHistoryRecord, len(result.Records))
 	for i, r := range result.Records {
 		records[i] = AuditHistoryRecord{
 			ObjectID:  r.ObjectID,
 			Operation: audit.FormatOperation(r.Operation),
+			Label:     audit.ResolveLabelWithDeleted(r.LabelHash, labelMap, deletedMap),
 			LabelHash: r.LabelHash,
 			Timestamp: r.Timestamp,
 			HashValue: r.HashValue,

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -228,6 +228,13 @@ func (a *App) UnlockVault(path, passphrase string) error {
 		}
 	}
 
+	// Emit vault-unlock after builder is wired up and passphrase is still available.
+	if a.builder != nil {
+		if logErr := a.builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: audit log failed: %v\n", logErr)
+		}
+	}
+
 	// Zero passphrase AFTER builder construction.
 	zeroBytes(passBytes)
 
@@ -244,6 +251,9 @@ func (a *App) UnlockVault(path, passphrase string) error {
 // It emits a "vault:locked" event to the frontend.
 func (a *App) LockVault() {
 	if a.builder != nil {
+		if logErr := a.builder.LogEvent("vault-lock", "", "", audit.Hostname(), true); logErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: audit log failed: %v\n", logErr)
+		}
 		_ = a.builder.Close()
 		a.builder = nil
 	}

--- a/cmd/tegata-gui/frontend/src/components/audit/AuditPanel.test.tsx
+++ b/cmd/tegata-gui/frontend/src/components/audit/AuditPanel.test.tsx
@@ -28,7 +28,7 @@ describe("AuditPanel", () => {
 
   it("fetches and displays history", async () => {
     vi.mocked(App.GetAuditHistory).mockResolvedValue([
-      { object_id: "evt-1", operation: "totp", label_hash: "abc123def456", timestamp: 1700000000, hash_value: "abcd1234" },
+      { object_id: "evt-1", operation: "TOTP", label: "GitHub", label_hash: "abc123def456", timestamp: 1700000000, hash_value: "abcd1234" },
     ])
 
     render(<AuditPanel open={true} onClose={() => {}} />)

--- a/cmd/tegata-gui/frontend/src/components/audit/AuditPanel.tsx
+++ b/cmd/tegata-gui/frontend/src/components/audit/AuditPanel.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useState } from "react"
 import { AlertTriangle, CheckCircle, Shield, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { App } from "@/lib/wails"
 import type { AuditHistoryRecord, AuditVerifyResult } from "@/lib/types"
-import { cn, formatError, hashString } from "@/lib/utils"
+import { cn, formatError } from "@/lib/utils"
 
 function formatFault(f: string): string {
   const idx = f.indexOf(": ")
@@ -17,27 +17,6 @@ function formatFault(f: string): string {
   return `The ${detail} for record ${id}`
 }
 
-const operationLabels: Record<string, string> = {
-  totp: "TOTP",
-  hotp: "HOTP",
-  static: "Static password",
-  "challenge-response": "Challenge-response",
-}
-
-async function buildLabelMap(): Promise<Record<string, string>> {
-  try {
-    const creds = await App.ListCredentials()
-    const map: Record<string, string> = {}
-    for (const cred of creds || []) {
-      const hash = await hashString(cred.label)
-      map[hash] = cred.label
-    }
-    return map
-  } catch {
-    return {}
-  }
-}
-
 interface AuditPanelProps {
   open: boolean
   onClose: () => void
@@ -48,22 +27,15 @@ export function AuditPanel({ open, onClose }: AuditPanelProps) {
   const [verifyResult, setVerifyResult] = useState<AuditVerifyResult | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState("")
-  const [labelMap, setLabelMap] = useState<Record<string, string>>({})
   const [dockerPath, setDockerPath] = useState("")
 
   useEffect(() => {
     if (open) {
       setError("")
       setVerifyResult(null)
-      buildLabelMap().then(setLabelMap)
       App.GetAuditDockerPath().then((p) => setDockerPath(p ?? "")).catch(() => setDockerPath(""))
     }
   }, [open])
-
-  const resolveLabel = useCallback(
-    (hash: string) => labelMap[hash] ?? "(deleted)",
-    [labelMap],
-  )
 
   async function handleFetchHistory() {
     setLoading(true)
@@ -200,8 +172,8 @@ export function AuditPanel({ open, onClose }: AuditPanelProps) {
                       <tbody>
                         {history.map((record, i) => (
                           <tr key={i} className="border-b last:border-0">
-                            <td className="p-2">{operationLabels[record.operation] ?? record.operation}</td>
-                            <td className="p-2">{resolveLabel(record.label_hash)}</td>
+                            <td className="p-2">{record.operation}</td>
+                            <td className="p-2">{record.label}</td>
                             <td className="p-2 text-muted-foreground">
                               {record.timestamp ? new Date(record.timestamp * 1000).toLocaleString() : "\u2014"}
                             </td>

--- a/cmd/tegata-gui/frontend/src/lib/types.ts
+++ b/cmd/tegata-gui/frontend/src/lib/types.ts
@@ -36,6 +36,7 @@ export interface UpdateInfo {
 export interface AuditHistoryRecord {
   object_id: string
   operation: string
+  label: string
   label_hash: string
   timestamp: number
   hash_value: string

--- a/cmd/tegata/add.go
+++ b/cmd/tegata/add.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/auth"
+	"github.com/josh-wong/tegata/internal/config"
 	"github.com/josh-wong/tegata/internal/errors"
 	pkgmodel "github.com/josh-wong/tegata/pkg/model"
 	"github.com/spf13/cobra"
@@ -53,6 +55,23 @@ func newAddCmd() *cobra.Command {
 				return err
 			}
 			defer mgr.Close()
+
+			cfg, _ := config.Load(vaultDir(vaultPath))
+			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+			}
+			if builder != nil {
+				defer func() { _ = builder.Close() }()
+				builder.OnHashStored = func(eventID, hashValue string) {
+					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+					}
+				}
+				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
+			}
 
 			var cred pkgmodel.Credential
 
@@ -121,6 +140,12 @@ func newAddCmd() *cobra.Command {
 				return err
 			}
 			_ = id
+
+			if builder != nil {
+				if logErr := builder.LogEvent("credential-add", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
+			}
 
 			displayIssuer := cred.Issuer
 			if displayIssuer == "" {

--- a/cmd/tegata/add.go
+++ b/cmd/tegata/add.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/auth"
-	"github.com/josh-wong/tegata/internal/config"
 	"github.com/josh-wong/tegata/internal/errors"
 	pkgmodel "github.com/josh-wong/tegata/pkg/model"
 	"github.com/spf13/cobra"
@@ -56,21 +55,9 @@ func newAddCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
-			cfg, _ := config.Load(vaultDir(vaultPath))
-			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
-			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
-			}
+			builder := setupAuditBuilder(cmd.ErrOrStderr(), vaultDir(vaultPath), passphrase, mgr)
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
-				builder.OnHashStored = func(eventID, hashValue string) {
-					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
-					}
-				}
-				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
-				}
 			}
 
 			var cred pkgmodel.Credential

--- a/cmd/tegata/add.go
+++ b/cmd/tegata/add.go
@@ -59,17 +59,17 @@ func newAddCmd() *cobra.Command {
 			cfg, _ := config.Load(vaultDir(vaultPath))
 			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
 			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
 				builder.OnHashStored = func(eventID, hashValue string) {
 					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 					}
 				}
 				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -143,7 +143,7 @@ func newAddCmd() *cobra.Command {
 
 			if builder != nil {
 				if logErr := builder.LogEvent("credential-add", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 

--- a/cmd/tegata/bench.go
+++ b/cmd/tegata/bench.go
@@ -48,7 +48,7 @@ func newBenchCmd() *cobra.Command {
 			fmt.Println("Target: under 3000ms")
 
 			if avg > 3*time.Second {
-				fmt.Println("\nWarning: unlock time exceeds 3s target. Consider reducing Argon2id parameters.")
+				fmt.Println("\nWarning: Unlock time exceeds 3s target. Consider reducing Argon2id parameters.")
 			}
 
 			return nil

--- a/cmd/tegata/change_passphrase.go
+++ b/cmd/tegata/change_passphrase.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/josh-wong/tegata/internal/audit"
+	"github.com/josh-wong/tegata/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +32,31 @@ func newChangePassphraseCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
+			// Use an in-memory queue rather than the disk-backed queue: after the
+			// passphrase changes, the queue key (derived from the old passphrase)
+			// becomes invalid, so writing it to disk would leave an unreadable file.
+			cfg, _ := config.Load(vaultDir(vaultPath))
+			var builder *audit.EventBuilder
+			if cfg.Audit.Enabled {
+				auditClient, clientErr := audit.NewClientFromConfig(cfg.Audit)
+				if clientErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", clientErr)
+				} else {
+					defer func() { _ = auditClient.Close() }()
+					builder, _ = audit.NewEventBuilderMemQueue(auditClient)
+				}
+			}
+			if builder != nil {
+				builder.OnHashStored = func(eventID, hashValue string) {
+					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+					}
+				}
+				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
+			}
+
 			newPassphrase, err := promptNewPassphrase()
 			if err != nil {
 				return err
@@ -38,6 +65,13 @@ func newChangePassphraseCmd() *cobra.Command {
 
 			if err := mgr.ChangePassphrase(newPassphrase); err != nil {
 				return fmt.Errorf("changing passphrase: %w", err)
+			}
+
+			if builder != nil {
+				if logErr := builder.LogEvent("vault-passphrase-change", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
+				_ = builder.Close()
 			}
 
 			fmt.Println("Passphrase changed successfully.")

--- a/cmd/tegata/change_passphrase.go
+++ b/cmd/tegata/change_passphrase.go
@@ -51,6 +51,14 @@ func newChangePassphraseCmd() *cobra.Command {
 				}
 			}
 			if builder != nil {
+				// Deferred close acts as a safety net for early returns. The explicit
+				// builder.Close() call below (after the passphrase-change event) is
+				// the normal path; this only fires if an early return is hit first.
+				defer func() {
+					if builder != nil {
+						_ = builder.Close()
+					}
+				}()
 				builder.OnHashStored = func(eventID, hashValue string) {
 					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
 						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
@@ -76,6 +84,7 @@ func newChangePassphraseCmd() *cobra.Command {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 				_ = builder.Close()
+				builder = nil // prevent deferred safety-net close from double-closing
 			}
 
 			fmt.Println("Passphrase changed successfully.")

--- a/cmd/tegata/change_passphrase.go
+++ b/cmd/tegata/change_passphrase.go
@@ -40,24 +40,24 @@ func newChangePassphraseCmd() *cobra.Command {
 			if cfg.Audit.Enabled {
 				auditClient, clientErr := audit.NewClientFromConfig(cfg.Audit)
 				if clientErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", clientErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", clientErr)
 				} else {
 					defer func() { _ = auditClient.Close() }()
 					var memErr error
 					builder, memErr = audit.NewEventBuilderMemQueue(auditClient)
 					if memErr != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", memErr)
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", memErr)
 					}
 				}
 			}
 			if builder != nil {
 				builder.OnHashStored = func(eventID, hashValue string) {
 					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 					}
 				}
 				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -73,7 +73,7 @@ func newChangePassphraseCmd() *cobra.Command {
 
 			if builder != nil {
 				if logErr := builder.LogEvent("vault-passphrase-change", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 				_ = builder.Close()
 			}

--- a/cmd/tegata/change_passphrase.go
+++ b/cmd/tegata/change_passphrase.go
@@ -43,7 +43,11 @@ func newChangePassphraseCmd() *cobra.Command {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", clientErr)
 				} else {
 					defer func() { _ = auditClient.Close() }()
-					builder, _ = audit.NewEventBuilderMemQueue(auditClient)
+					var memErr error
+					builder, memErr = audit.NewEventBuilderMemQueue(auditClient)
+					if memErr != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", memErr)
+					}
 				}
 			}
 			if builder != nil {

--- a/cmd/tegata/code.go
+++ b/cmd/tegata/code.go
@@ -45,24 +45,11 @@ func newCodeCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
-			// Load config before zeroing passphrase; build audit builder while
-			// passphrase is still available.
+			// Load config for clipboard settings; build audit builder while passphrase is still in scope.
 			cfg, _ := config.Load(vaultDir(vaultPath))
-			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
-			if err != nil {
-				// Non-fatal: log and continue without audit.
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
-			}
+			builder := setupAuditBuilder(cmd.ErrOrStderr(), vaultDir(vaultPath), passphrase, mgr)
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
-				builder.OnHashStored = func(eventID, hashValue string) {
-					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
-					}
-				}
-				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
-				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/code.go
+++ b/cmd/tegata/code.go
@@ -60,6 +60,9 @@ func newCodeCmd() *cobra.Command {
 						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
 					}
 				}
+				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/code.go
+++ b/cmd/tegata/code.go
@@ -51,17 +51,17 @@ func newCodeCmd() *cobra.Command {
 			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
 			if err != nil {
 				// Non-fatal: log and continue without audit.
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
 				builder.OnHashStored = func(eventID, hashValue string) {
 					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 					}
 				}
 				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -110,7 +110,7 @@ func newCodeCmd() *cobra.Command {
 			if builder != nil {
 				opType := string(cred.Type)
 				if logErr := builder.LogEvent(opType, cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 

--- a/cmd/tegata/export.go
+++ b/cmd/tegata/export.go
@@ -57,17 +57,17 @@ func runExport(cmd *cobra.Command, args []string) error {
 	cfg, _ := config.Load(vaultDir(vaultPath))
 	builder, builderErr := newEventBuilder(cfg, vaultDir(vaultPath), vaultPass)
 	if builderErr != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", builderErr)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", builderErr)
 	}
 	if builder != nil {
 		defer func() { _ = builder.Close() }()
 		builder.OnHashStored = func(eventID, hashValue string) {
 			if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 			}
 		}
 		if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 		}
 	}
 
@@ -125,7 +125,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 	if builder != nil {
 		if logErr := builder.LogEvent("credential-export", "", "", audit.Hostname(), true); logErr != nil {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 		}
 	}
 

--- a/cmd/tegata/export.go
+++ b/cmd/tegata/export.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 
 	"github.com/josh-wong/tegata/internal/audit"
-	"github.com/josh-wong/tegata/internal/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -54,21 +53,9 @@ func runExport(cmd *cobra.Command, args []string) error {
 	}
 	defer mgr.Close()
 
-	cfg, _ := config.Load(vaultDir(vaultPath))
-	builder, builderErr := newEventBuilder(cfg, vaultDir(vaultPath), vaultPass)
-	if builderErr != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", builderErr)
-	}
+	builder := setupAuditBuilder(cmd.ErrOrStderr(), vaultDir(vaultPath), vaultPass, mgr)
 	if builder != nil {
 		defer func() { _ = builder.Close() }()
-		builder.OnHashStored = func(eventID, hashValue string) {
-			if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
-			}
-		}
-		if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
-		}
 	}
 
 	// Prompt for export passphrase directly via term.ReadPassword.

--- a/cmd/tegata/export.go
+++ b/cmd/tegata/export.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/josh-wong/tegata/internal/audit"
+	"github.com/josh-wong/tegata/internal/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -51,6 +53,23 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not unlock vault: %w", err)
 	}
 	defer mgr.Close()
+
+	cfg, _ := config.Load(vaultDir(vaultPath))
+	builder, builderErr := newEventBuilder(cfg, vaultDir(vaultPath), vaultPass)
+	if builderErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", builderErr)
+	}
+	if builder != nil {
+		defer func() { _ = builder.Close() }()
+		builder.OnHashStored = func(eventID, hashValue string) {
+			if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+			}
+		}
+		if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+		}
+	}
 
 	// Prompt for export passphrase directly via term.ReadPassword.
 	// The export passphrase is a new credential and must never be read from
@@ -102,6 +121,12 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 	if err := os.WriteFile(outPath, data, 0600); err != nil {
 		return fmt.Errorf("writing backup file %q: %w", outPath, err)
+	}
+
+	if builder != nil {
+		if logErr := builder.LogEvent("credential-export", "", "", audit.Hostname(), true); logErr != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+		}
 	}
 
 	credCount := len(mgr.ListCredentials())

--- a/cmd/tegata/get.go
+++ b/cmd/tegata/get.go
@@ -43,17 +43,17 @@ func newGetCmd() *cobra.Command {
 			cfg, _ := config.Load(vaultDir(vaultPath))
 			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
 			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
 				builder.OnHashStored = func(eventID, hashValue string) {
 					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 					}
 				}
 				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -71,14 +71,14 @@ func newGetCmd() *cobra.Command {
 			// Emit audit event after successful static password retrieval.
 			if builder != nil {
 				if logErr := builder.LogEvent("static", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
 			cm := clipboard.NewManager()
 			defer cm.Close()
 			if err := cm.CopyWithAutoClear(string(password), cfg.ClipboardTimeout); err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: clipboard copy failed: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Clipboard copy failed: %v\n", err)
 			} else {
 				fmt.Printf("Copied to clipboard (auto-clear in %ds)\n",
 					int(cfg.ClipboardTimeout.Seconds()))

--- a/cmd/tegata/get.go
+++ b/cmd/tegata/get.go
@@ -52,6 +52,9 @@ func newGetCmd() *cobra.Command {
 						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
 					}
 				}
+				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/get.go
+++ b/cmd/tegata/get.go
@@ -39,22 +39,11 @@ func newGetCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
-			// Load config and build audit builder while passphrase is in scope.
+			// Load config for clipboard settings; build audit builder while passphrase is still in scope.
 			cfg, _ := config.Load(vaultDir(vaultPath))
-			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
-			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
-			}
+			builder := setupAuditBuilder(cmd.ErrOrStderr(), vaultDir(vaultPath), passphrase, mgr)
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
-				builder.OnHashStored = func(eventID, hashValue string) {
-					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
-					}
-				}
-				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
-				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/helpers.go
+++ b/cmd/tegata/helpers.go
@@ -294,6 +294,31 @@ func newEventBuilder(cfg config.Config, vaultDir string, passphrase []byte) (*au
 	return audit.NewEventBuilderFromConfig(cfg.Audit, vaultDir, passphrase)
 }
 
+// setupAuditBuilder loads config, initialises an EventBuilder, wires up the
+// OnHashStored callback so hashes are persisted in the vault, and emits a
+// vault-unlock event. Returns nil when audit is disabled or unavailable.
+// The caller must defer builder.Close() when the return value is non-nil.
+func setupAuditBuilder(w io.Writer, dir string, passphrase []byte, mgr *vault.Manager) *audit.EventBuilder {
+	cfg, _ := config.Load(dir)
+	builder, err := newEventBuilder(cfg, dir, passphrase)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "Warning: Audit unavailable: %v\n", err)
+		return nil
+	}
+	if builder == nil {
+		return nil
+	}
+	builder.OnHashStored = func(eventID, hashValue string) {
+		if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+			_, _ = fmt.Fprintf(w, "Warning: Failed to store audit hash: %v\n", err)
+		}
+	}
+	if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+		_, _ = fmt.Fprintf(w, "Warning: Audit log failed: %v\n", logErr)
+	}
+	return builder
+}
+
 // humanizeError translates OS and filesystem errors into user-friendly messages.
 // Falls through to the original error for unknown types.
 func humanizeError(err error) string {

--- a/cmd/tegata/helpers.go
+++ b/cmd/tegata/helpers.go
@@ -322,6 +322,7 @@ func setupAuditBuilder(w io.Writer, dir string, passphrase []byte, mgr *vault.Ma
 	if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
 		_, _ = fmt.Fprintf(w, "Warning: Audit log failed: %v\n", logErr)
 	}
+	builder.LogVaultLockOnClose = true
 	return builder
 }
 

--- a/cmd/tegata/helpers.go
+++ b/cmd/tegata/helpers.go
@@ -298,6 +298,12 @@ func newEventBuilder(cfg config.Config, vaultDir string, passphrase []byte) (*au
 // OnHashStored callback so hashes are persisted in the vault, and emits a
 // vault-unlock event. Returns nil when audit is disabled or unavailable.
 // The caller must defer builder.Close() when the return value is non-nil.
+//
+// Every CLI invocation that opens the vault logs a vault-unlock event followed
+// by the operation-specific event. This is intentional: each invocation
+// decrypts the vault from scratch, so vault-unlock accurately reflects that a
+// session was started. Audit consumers will see one vault-unlock per command
+// (e.g. tegata add → vault-unlock + credential-add).
 func setupAuditBuilder(w io.Writer, dir string, passphrase []byte, mgr *vault.Manager) *audit.EventBuilder {
 	cfg, _ := config.Load(dir)
 	builder, err := newEventBuilder(cfg, dir, passphrase)

--- a/cmd/tegata/history.go
+++ b/cmd/tegata/history.go
@@ -68,6 +68,7 @@ Requires audit to be enabled in tegata.toml ([audit] enabled = true).`,
 				labels[i] = c.Label
 			}
 			labelMap := audit.BuildLabelMap(labels)
+			deletedMap := mgr.DeletedLabels()
 
 			client, err := audit.NewClientFromConfig(cfg.Audit)
 			if err != nil {
@@ -101,14 +102,14 @@ Requires audit to be enabled in tegata.toml ([audit] enabled = true).`,
 			// Parse --from and --to date filters.
 			var fromTime, toTime time.Time
 			if from != "" {
-				fromTime, err = time.Parse("2006-01-02", from)
+				fromTime, err = time.ParseInLocation("2006-01-02", from, time.Local)
 				if err != nil {
 					return fmt.Errorf("invalid --from date %q (expected YYYY-MM-DD): %w",
 						from, tegerrors.ErrInvalidInput)
 				}
 			}
 			if to != "" {
-				toTime, err = time.Parse("2006-01-02", to)
+				toTime, err = time.ParseInLocation("2006-01-02", to, time.Local)
 				if err != nil {
 					return fmt.Errorf("invalid --to date %q (expected YYYY-MM-DD): %w",
 						to, tegerrors.ErrInvalidInput)
@@ -126,7 +127,7 @@ Requires audit to be enabled in tegata.toml ([audit] enabled = true).`,
 				return enc.Encode(filtered)
 			}
 
-			printRecordsTable(filtered, labelMap)
+			printRecordsTable(filtered, labelMap, deletedMap)
 			return nil
 		},
 	}
@@ -155,7 +156,7 @@ func filterRecords(records []historyRecord, from, to time.Time) []historyRecord 
 	}
 	var filtered []historyRecord
 	for _, r := range records {
-		t := time.Unix(r.Timestamp, 0).UTC()
+		t := time.Unix(r.Timestamp, 0).Local()
 		if !from.IsZero() && t.Before(from) {
 			continue
 		}
@@ -169,8 +170,8 @@ func filterRecords(records []historyRecord, from, to time.Time) []historyRecord 
 
 // printRecordsTable writes a human-readable tabular display of history records
 // with operation, label, timestamp, and hash columns. Labels are resolved from
-// hashes using labelMap; unresolved hashes are truncated to 12 characters.
-func printRecordsTable(records []historyRecord, labelMap map[string]string) {
+// hashes using labelMap and deletedMap; deleted credentials show as "Label (deleted)".
+func printRecordsTable(records []historyRecord, labelMap, deletedMap map[string]string) {
 	if len(records) == 0 {
 		fmt.Println("No audit events found.")
 		return
@@ -180,9 +181,9 @@ func printRecordsTable(records []historyRecord, labelMap map[string]string) {
 	_, _ = fmt.Fprintln(w, "Operation\tLabel\tTimestamp\tHash")
 	_, _ = fmt.Fprintln(w, "---------\t-----\t---------\t----")
 	for _, r := range records {
-		label := audit.ResolveLabel(r.LabelHash, labelMap)
+		label := audit.ResolveLabelWithDeleted(r.LabelHash, labelMap, deletedMap)
 		op := audit.FormatOperation(r.Operation)
-		ts := time.Unix(r.Timestamp, 0).UTC().Format("2006-01-02 15:04:05")
+		ts := time.Unix(r.Timestamp, 0).Local().Format("2006-01-02 15:04:05")
 		hash := r.HashValue
 		if len(hash) > 16 {
 			hash = hash[:16] + "..."

--- a/cmd/tegata/import.go
+++ b/cmd/tegata/import.go
@@ -57,17 +57,17 @@ func runImport(cmd *cobra.Command, args []string) error {
 	cfg, _ := config.Load(vaultDir(vaultPath))
 	builder, builderErr := newEventBuilder(cfg, vaultDir(vaultPath), vaultPass)
 	if builderErr != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", builderErr)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", builderErr)
 	}
 	if builder != nil {
 		defer func() { _ = builder.Close() }()
 		builder.OnHashStored = func(eventID, hashValue string) {
 			if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 			}
 		}
 		if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 		}
 	}
 
@@ -109,7 +109,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 
 	if builder != nil && imported > 0 {
 		if logErr := builder.LogEvent("credential-import", "", "", audit.Hostname(), true); logErr != nil {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 		}
 	}
 

--- a/cmd/tegata/import.go
+++ b/cmd/tegata/import.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/josh-wong/tegata/internal/audit"
+	"github.com/josh-wong/tegata/internal/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -52,6 +54,23 @@ func runImport(cmd *cobra.Command, args []string) error {
 	}
 	defer mgr.Close()
 
+	cfg, _ := config.Load(vaultDir(vaultPath))
+	builder, builderErr := newEventBuilder(cfg, vaultDir(vaultPath), vaultPass)
+	if builderErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", builderErr)
+	}
+	if builder != nil {
+		defer func() { _ = builder.Close() }()
+		builder.OnHashStored = func(eventID, hashValue string) {
+			if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+			}
+		}
+		if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+		}
+	}
+
 	// Read backup file with size guard (10 MB max, matching GUI).
 	const maxImportSize = 10 << 20
 	info, err := os.Stat(backupPath)
@@ -86,6 +105,12 @@ func runImport(cmd *cobra.Command, args []string) error {
 	imported, skipped, err := mgr.ImportCredentials(data, importPass)
 	if err != nil {
 		return fmt.Errorf("import failed: %w", err)
+	}
+
+	if builder != nil && imported > 0 {
+		if logErr := builder.LogEvent("credential-import", "", "", audit.Hostname(), true); logErr != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+		}
 	}
 
 	fmt.Printf("%d imported, %d skipped (duplicate label)\n", imported, skipped)

--- a/cmd/tegata/import.go
+++ b/cmd/tegata/import.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/josh-wong/tegata/internal/audit"
-	"github.com/josh-wong/tegata/internal/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -54,21 +53,9 @@ func runImport(cmd *cobra.Command, args []string) error {
 	}
 	defer mgr.Close()
 
-	cfg, _ := config.Load(vaultDir(vaultPath))
-	builder, builderErr := newEventBuilder(cfg, vaultDir(vaultPath), vaultPass)
-	if builderErr != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", builderErr)
-	}
+	builder := setupAuditBuilder(cmd.ErrOrStderr(), vaultDir(vaultPath), vaultPass, mgr)
 	if builder != nil {
 		defer func() { _ = builder.Close() }()
-		builder.OnHashStored = func(eventID, hashValue string) {
-			if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
-			}
-		}
-		if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
-		}
 	}
 
 	// Read backup file with size guard (10 MB max, matching GUI).

--- a/cmd/tegata/init.go
+++ b/cmd/tegata/init.go
@@ -68,7 +68,7 @@ vault directory; otherwise the current directory is used.`,
 
 			// Write default config alongside the vault.
 			if err := config.WriteDefaults(dir); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: could not write default config: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Warning: Could not write default config: %v\n", err)
 			}
 
 			fmt.Printf("Vault created: %s\n\n", vaultPath)
@@ -133,7 +133,7 @@ func runInitAudit(vaultPath, dir string, passphrase []byte) {
 	}
 
 	if writeErr := config.WriteAuditSection(dir, auditCfg); writeErr != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not save audit config: %v\n", writeErr)
+		fmt.Fprintf(os.Stderr, "Warning: Could not save audit config: %v\n", writeErr)
 		return
 	}
 

--- a/cmd/tegata/remove.go
+++ b/cmd/tegata/remove.go
@@ -37,17 +37,17 @@ func newRemoveCmd() *cobra.Command {
 			cfg, _ := config.Load(vaultDir(vaultPath))
 			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
 			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
 				builder.OnHashStored = func(eventID, hashValue string) {
 					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 					}
 				}
 				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -68,7 +68,7 @@ func newRemoveCmd() *cobra.Command {
 
 			if builder != nil {
 				if logErr := builder.LogEvent("credential-remove", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 

--- a/cmd/tegata/remove.go
+++ b/cmd/tegata/remove.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/josh-wong/tegata/internal/audit"
-	"github.com/josh-wong/tegata/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -34,21 +33,9 @@ func newRemoveCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
-			cfg, _ := config.Load(vaultDir(vaultPath))
-			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
-			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
-			}
+			builder := setupAuditBuilder(cmd.ErrOrStderr(), vaultDir(vaultPath), passphrase, mgr)
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
-				builder.OnHashStored = func(eventID, hashValue string) {
-					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
-					}
-				}
-				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
-				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/remove.go
+++ b/cmd/tegata/remove.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/josh-wong/tegata/internal/audit"
+	"github.com/josh-wong/tegata/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +34,23 @@ func newRemoveCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
+			cfg, _ := config.Load(vaultDir(vaultPath))
+			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+			}
+			if builder != nil {
+				defer func() { _ = builder.Close() }()
+				builder.OnHashStored = func(eventID, hashValue string) {
+					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+					}
+				}
+				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
+			}
+
 			cred, err := mgr.GetCredential(label)
 			if err != nil {
 				return err
@@ -45,6 +64,12 @@ func newRemoveCmd() *cobra.Command {
 
 			if err := mgr.RemoveCredential(cred.ID); err != nil {
 				return err
+			}
+
+			if builder != nil {
+				if logErr := builder.LogEvent("credential-remove", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
 			}
 
 			fmt.Printf("Removed: %s\n", label)

--- a/cmd/tegata/resync.go
+++ b/cmd/tegata/resync.go
@@ -86,7 +86,7 @@ func newResyncCmd() *cobra.Command {
 			}
 
 			if builder != nil {
-				if logErr := builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+				if logErr := builder.LogEvent("hotp-resync", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}

--- a/cmd/tegata/resync.go
+++ b/cmd/tegata/resync.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/auth"
-	"github.com/josh-wong/tegata/internal/config"
 	"github.com/josh-wong/tegata/internal/errors"
 	"github.com/spf13/cobra"
 )
@@ -39,21 +38,9 @@ func newResyncCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
-			cfg, _ := config.Load(vaultDir(vaultPath))
-			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
-			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
-			}
+			builder := setupAuditBuilder(cmd.ErrOrStderr(), vaultDir(vaultPath), passphrase, mgr)
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
-				builder.OnHashStored = func(eventID, hashValue string) {
-					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
-					}
-				}
-				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
-				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/resync.go
+++ b/cmd/tegata/resync.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/auth"
+	"github.com/josh-wong/tegata/internal/config"
 	"github.com/josh-wong/tegata/internal/errors"
 	"github.com/spf13/cobra"
 )
@@ -36,6 +38,23 @@ func newResyncCmd() *cobra.Command {
 				return err
 			}
 			defer mgr.Close()
+
+			cfg, _ := config.Load(vaultDir(vaultPath))
+			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+			}
+			if builder != nil {
+				defer func() { _ = builder.Close() }()
+				builder.OnHashStored = func(eventID, hashValue string) {
+					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+					}
+				}
+				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
+			}
 
 			cred, err := mgr.GetCredential(label)
 			if err != nil {
@@ -77,6 +96,12 @@ func newResyncCmd() *cobra.Command {
 			cred.Counter = newCounter
 			if err := mgr.UpdateCredential(cred); err != nil {
 				return fmt.Errorf("saving counter: %w", err)
+			}
+
+			if builder != nil {
+				if logErr := builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
 			}
 
 			fmt.Printf("Counter resynchronized. Next code will use counter %d.\n", newCounter)

--- a/cmd/tegata/resync.go
+++ b/cmd/tegata/resync.go
@@ -42,17 +42,17 @@ func newResyncCmd() *cobra.Command {
 			cfg, _ := config.Load(vaultDir(vaultPath))
 			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
 			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
 				builder.OnHashStored = func(eventID, hashValue string) {
 					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 					}
 				}
 				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -100,7 +100,7 @@ func newResyncCmd() *cobra.Command {
 
 			if builder != nil {
 				if logErr := builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 

--- a/cmd/tegata/sign.go
+++ b/cmd/tegata/sign.go
@@ -52,17 +52,17 @@ func newSignCmd() *cobra.Command {
 			cfg, _ := config.Load(vaultDir(vaultPath))
 			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
 			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
 				builder.OnHashStored = func(eventID, hashValue string) {
 					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 					}
 				}
 				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -87,7 +87,7 @@ func newSignCmd() *cobra.Command {
 			// Emit audit event after successful sign.
 			if builder != nil {
 				if logErr := builder.LogEvent("challenge-response", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -95,7 +95,7 @@ func newSignCmd() *cobra.Command {
 				cm := clipboard.NewManager()
 				defer cm.Close()
 				if copyErr := cm.CopyWithAutoClear(hexResult, cfg.ClipboardTimeout); copyErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: clipboard copy failed: %v\n", copyErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Clipboard copy failed: %v\n", copyErr)
 				} else {
 					_, _ = fmt.Fprintf(os.Stderr, "Copied to clipboard (auto-clear in %ds)\n",
 						int(cfg.ClipboardTimeout.Seconds()))

--- a/cmd/tegata/sign.go
+++ b/cmd/tegata/sign.go
@@ -48,22 +48,11 @@ func newSignCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
-			// Load config and build audit builder while passphrase is in scope.
+			// Load config for clipboard settings; build audit builder while passphrase is still in scope.
 			cfg, _ := config.Load(vaultDir(vaultPath))
-			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
-			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
-			}
+			builder := setupAuditBuilder(cmd.ErrOrStderr(), vaultDir(vaultPath), passphrase, mgr)
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
-				builder.OnHashStored = func(eventID, hashValue string) {
-					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
-					}
-				}
-				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
-				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/sign.go
+++ b/cmd/tegata/sign.go
@@ -61,6 +61,9 @@ func newSignCmd() *cobra.Command {
 						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
 					}
 				}
+				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/tag_cmd.go
+++ b/cmd/tegata/tag_cmd.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/josh-wong/tegata/internal/audit"
+	"github.com/josh-wong/tegata/internal/config"
 	"github.com/josh-wong/tegata/internal/errors"
 	"github.com/spf13/cobra"
 )
@@ -47,6 +49,23 @@ func newTagCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
+			cfg, _ := config.Load(vaultDir(vaultPath))
+			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+			}
+			if builder != nil {
+				defer func() { _ = builder.Close() }()
+				builder.OnHashStored = func(eventID, hashValue string) {
+					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+					}
+				}
+				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
+			}
+
 			cred, err := mgr.GetCredential(label)
 			if err != nil {
 				return err
@@ -81,6 +100,12 @@ func newTagCmd() *cobra.Command {
 
 			if err := mgr.UpdateCredential(cred); err != nil {
 				return err
+			}
+
+			if builder != nil {
+				if logErr := builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+				}
 			}
 
 			if len(cred.Tags) == 0 {

--- a/cmd/tegata/tag_cmd.go
+++ b/cmd/tegata/tag_cmd.go
@@ -52,17 +52,17 @@ func newTagCmd() *cobra.Command {
 			cfg, _ := config.Load(vaultDir(vaultPath))
 			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
 			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit unavailable: %v\n", err)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
 			}
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
 				builder.OnHashStored = func(eventID, hashValue string) {
 					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to store audit hash: %v\n", err)
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
 					}
 				}
 				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -104,7 +104,7 @@ func newTagCmd() *cobra.Command {
 
 			if builder != nil {
 				if logErr := builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 

--- a/cmd/tegata/tag_cmd.go
+++ b/cmd/tegata/tag_cmd.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/josh-wong/tegata/internal/audit"
-	"github.com/josh-wong/tegata/internal/config"
 	"github.com/josh-wong/tegata/internal/errors"
 	"github.com/spf13/cobra"
 )
@@ -49,21 +48,9 @@ func newTagCmd() *cobra.Command {
 			}
 			defer mgr.Close()
 
-			cfg, _ := config.Load(vaultDir(vaultPath))
-			builder, err := newEventBuilder(cfg, vaultDir(vaultPath), passphrase)
-			if err != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit unavailable: %v\n", err)
-			}
+			builder := setupAuditBuilder(cmd.ErrOrStderr(), vaultDir(vaultPath), passphrase, mgr)
 			if builder != nil {
 				defer func() { _ = builder.Close() }()
-				builder.OnHashStored = func(eventID, hashValue string) {
-					if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to store audit hash: %v\n", err)
-					}
-				}
-				if logErr := builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
-				}
 			}
 
 			cred, err := mgr.GetCredential(label)

--- a/cmd/tegata/tag_cmd.go
+++ b/cmd/tegata/tag_cmd.go
@@ -90,7 +90,7 @@ func newTagCmd() *cobra.Command {
 			}
 
 			if builder != nil {
-				if logErr := builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+				if logErr := builder.LogEvent("credential-tag-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Audit log failed: %v\n", logErr)
 				}
 			}

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -284,6 +285,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			effectiveState == stateOverlayAudit
 		if idleLockable && time.Since(m.lastActivity) >= m.idleTimeout {
 			if m.builder != nil {
+				if logErr := m.builder.LogEvent("vault-lock", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+				}
 				_ = m.builder.Close()
 				m.builder = nil
 			}

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -39,6 +39,10 @@ const (
 // tickMsg is fired every second to update the TOTP countdown and idle timer.
 type tickMsg struct{ t time.Time }
 
+// sigTermMsg is sent to the model when SIGTERM or SIGHUP is received, so the
+// normal quit() path runs and vault-lock is logged before the process exits.
+type sigTermMsg struct{}
+
 // model is the root Bubbletea model. It holds all application state for the
 // duration of a `tegata ui` session.
 type model struct {
@@ -257,6 +261,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.state = m.prevState
 		}
 		return m, nil
+
+	case sigTermMsg:
+		return m.quit()
 
 	case tea.KeyMsg:
 		// Ctrl+C always quits, even during text input.

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -286,7 +286,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if idleLockable && time.Since(m.lastActivity) >= m.idleTimeout {
 			if m.builder != nil {
 				if logErr := m.builder.LogEvent("vault-lock", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 				}
 				_ = m.builder.Close()
 				m.builder = nil
@@ -426,6 +426,9 @@ func (m model) View() string {
 // quit cleanly closes all resources and returns tea.Quit.
 func (m model) quit() (tea.Model, tea.Cmd) {
 	if m.builder != nil {
+		if logErr := m.builder.LogEvent("vault-lock", "", "", audit.Hostname(), true); logErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
+		}
 		_ = m.builder.Close()
 		m.builder = nil
 	}

--- a/cmd/tegata/tui_overlay_add.go
+++ b/cmd/tegata/tui_overlay_add.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/auth"
 	pkgmodel "github.com/josh-wong/tegata/pkg/model"
 )
@@ -298,6 +299,10 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
+			if m.builder != nil {
+				_ = m.builder.LogEvent("credential-add", cred.Label, cred.Issuer, audit.Hostname(), true)
+			}
+
 			m = refreshCredList(m, labelVal)
 
 			label := labelVal
@@ -441,6 +446,9 @@ func (m model) updateOverlayRemove(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.errMsg = fmt.Sprintf("Remove failed: %v", err)
 					m.state = stateMainView
 					return m, nil
+				}
+				if m.builder != nil {
+					_ = m.builder.LogEvent("credential-remove", item.cred.Label, item.cred.Issuer, audit.Hostname(), true)
 				}
 			}
 

--- a/cmd/tegata/tui_overlay_add.go
+++ b/cmd/tegata/tui_overlay_add.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -300,7 +301,9 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			if m.builder != nil {
-				_ = m.builder.LogEvent("credential-add", cred.Label, cred.Issuer, audit.Hostname(), true)
+				if logErr := m.builder.LogEvent("credential-add", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+				}
 			}
 
 			m = refreshCredList(m, labelVal)
@@ -448,7 +451,9 @@ func (m model) updateOverlayRemove(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 				if m.builder != nil {
-					_ = m.builder.LogEvent("credential-remove", item.cred.Label, item.cred.Issuer, audit.Hostname(), true)
+					if logErr := m.builder.LogEvent("credential-remove", item.cred.Label, item.cred.Issuer, audit.Hostname(), true); logErr != nil {
+						_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+					}
 				}
 			}
 

--- a/cmd/tegata/tui_overlay_add.go
+++ b/cmd/tegata/tui_overlay_add.go
@@ -302,7 +302,7 @@ func (m model) updateOverlayAdd(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if m.builder != nil {
 				if logErr := m.builder.LogEvent("credential-add", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -452,7 +452,7 @@ func (m model) updateOverlayRemove(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				if m.builder != nil {
 					if logErr := m.builder.LogEvent("credential-remove", item.cred.Label, item.cred.Issuer, audit.Hostname(), true); logErr != nil {
-						_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+						_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 					}
 				}
 			}

--- a/cmd/tegata/tui_overlay_audit.go
+++ b/cmd/tegata/tui_overlay_audit.go
@@ -113,6 +113,15 @@ func (m model) buildLabelMap() map[string]string {
 	return audit.BuildLabelMap(labels)
 }
 
+// buildDeletedLabelMap returns the vault's deleted-label hash→name map,
+// used to resolve labels for credentials that have been removed.
+func (m model) buildDeletedLabelMap() map[string]string {
+	if m.vaultMgr == nil {
+		return nil
+	}
+	return m.vaultMgr.DeletedLabels()
+}
+
 // resetAuditOverlay clears all audit overlay state.
 func (m *model) resetAuditOverlay() {
 	m.auditMenuIdx = 0
@@ -223,20 +232,21 @@ func (m model) viewAuditHistory() string {
 			helpBarStyle.Render("[Esc] Back")
 	}
 
-	// Build hash→label lookup from loaded credentials.
+	// Build hash→label lookup from loaded credentials and deleted labels.
 	labelMap := m.buildLabelMap()
+	deletedMap := m.buildDeletedLabelMap()
 
 	var body strings.Builder
 	if len(m.auditRecords) > 0 {
 		body.WriteString(fmt.Sprintf("%-20s %-20s %-20s %s\n", "Operation", "Label", "Timestamp", "Hash"))
 		body.WriteString(strings.Repeat("─", 80) + "\n")
 		for _, r := range m.auditRecords {
-			label := audit.ResolveLabel(r.LabelHash, labelMap)
+			label := audit.ResolveLabelWithDeleted(r.LabelHash, labelMap, deletedMap)
 			if len(label) > 20 {
 				label = label[:19] + "…"
 			}
 			op := audit.FormatOperation(r.Operation)
-			ts := time.Unix(r.Timestamp, 0).UTC().Format("2006-01-02 15:04:05")
+			ts := time.Unix(r.Timestamp, 0).Local().Format("2006-01-02 15:04:05")
 			hash := r.HashValue
 			if len(hash) > 16 {
 				hash = hash[:16] + "…"

--- a/cmd/tegata/tui_overlay_settings.go
+++ b/cmd/tegata/tui_overlay_settings.go
@@ -170,7 +170,7 @@ func (m model) updateSettingsTags(msg tea.Msg) (tea.Model, tea.Cmd) {
 							} else {
 								m.settingsMsg = fmt.Sprintf("Added tag %q", tag)
 								if m.builder != nil {
-									if logErr := m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+									if logErr := m.builder.LogEvent("credential-tag-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
 										_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 									}
 								}
@@ -237,7 +237,7 @@ func (m model) updateSettingsTags(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.settingsMsg = fmt.Sprintf("Removed tag %q", removed)
 					if m.builder != nil {
-						if logErr := m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+						if logErr := m.builder.LogEvent("credential-tag-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
 							_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 						}
 					}

--- a/cmd/tegata/tui_overlay_settings.go
+++ b/cmd/tegata/tui_overlay_settings.go
@@ -171,7 +171,7 @@ func (m model) updateSettingsTags(msg tea.Msg) (tea.Model, tea.Cmd) {
 								m.settingsMsg = fmt.Sprintf("Added tag %q", tag)
 								if m.builder != nil {
 									if logErr := m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-										_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+										_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 									}
 								}
 								m = refreshCredList(m)
@@ -238,7 +238,7 @@ func (m model) updateSettingsTags(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.settingsMsg = fmt.Sprintf("Removed tag %q", removed)
 					if m.builder != nil {
 						if logErr := m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
-							_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+							_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 						}
 					}
 					m = refreshCredList(m)
@@ -330,7 +330,7 @@ func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if m.builder != nil {
 				if logErr := m.builder.LogEvent("vault-passphrase-change", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -443,7 +443,7 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if m.builder != nil {
 				if logErr := m.builder.LogEvent("credential-export", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 
@@ -533,7 +533,7 @@ func (m model) updateSettingsImport(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if m.builder != nil && imported > 0 {
 				if logErr := m.builder.LogEvent("credential-import", "", "", audit.Hostname(), true); logErr != nil {
-					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+					_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 				}
 			}
 

--- a/cmd/tegata/tui_overlay_settings.go
+++ b/cmd/tegata/tui_overlay_settings.go
@@ -170,7 +170,9 @@ func (m model) updateSettingsTags(msg tea.Msg) (tea.Model, tea.Cmd) {
 							} else {
 								m.settingsMsg = fmt.Sprintf("Added tag %q", tag)
 								if m.builder != nil {
-									_ = m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true)
+									if logErr := m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+										_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+									}
 								}
 								m = refreshCredList(m)
 							}
@@ -235,7 +237,9 @@ func (m model) updateSettingsTags(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.settingsMsg = fmt.Sprintf("Removed tag %q", removed)
 					if m.builder != nil {
-						_ = m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true)
+						if logErr := m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true); logErr != nil {
+							_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+						}
 					}
 					m = refreshCredList(m)
 					if m.settingsTagIdx > 0 {
@@ -325,7 +329,9 @@ func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			if m.builder != nil {
-				_ = m.builder.LogEvent("vault-passphrase-change", "", "", audit.Hostname(), true)
+				if logErr := m.builder.LogEvent("vault-passphrase-change", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+				}
 			}
 
 			m.settingsInput1.Reset()
@@ -436,7 +442,9 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			if m.builder != nil {
-				_ = m.builder.LogEvent("credential-export", "", "", audit.Hostname(), true)
+				if logErr := m.builder.LogEvent("credential-export", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+				}
 			}
 
 			m.settingsInput1.Reset()
@@ -524,7 +532,9 @@ func (m model) updateSettingsImport(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			if m.builder != nil && imported > 0 {
-				_ = m.builder.LogEvent("credential-import", "", "", audit.Hostname(), true)
+				if logErr := m.builder.LogEvent("credential-import", "", "", audit.Hostname(), true); logErr != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+				}
 			}
 
 			if err := m.vaultMgr.Save(); err != nil {

--- a/cmd/tegata/tui_overlay_settings.go
+++ b/cmd/tegata/tui_overlay_settings.go
@@ -324,6 +324,10 @@ func (m model) updateSettingsPassphrase(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
+			if m.builder != nil {
+				_ = m.builder.LogEvent("vault-passphrase-change", "", "", audit.Hostname(), true)
+			}
+
 			m.settingsInput1.Reset()
 			m.settingsInput1.Blur()
 			m.settingsInput2.Reset()
@@ -429,6 +433,10 @@ func (m model) updateSettingsExport(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if err := os.WriteFile(path, data, 0600); err != nil {
 				m.settingsMsg = fmt.Sprintf("Write failed: %v", err)
 				return m, nil
+			}
+
+			if m.builder != nil {
+				_ = m.builder.LogEvent("credential-export", "", "", audit.Hostname(), true)
 			}
 
 			m.settingsInput1.Reset()

--- a/cmd/tegata/tui_overlay_settings.go
+++ b/cmd/tegata/tui_overlay_settings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/config"
 	"github.com/josh-wong/tegata/internal/vault"
 )
@@ -168,6 +169,9 @@ func (m model) updateSettingsTags(msg tea.Msg) (tea.Model, tea.Cmd) {
 								m.settingsMsg = fmt.Sprintf("Error: %v", err)
 							} else {
 								m.settingsMsg = fmt.Sprintf("Added tag %q", tag)
+								if m.builder != nil {
+									_ = m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true)
+								}
 								m = refreshCredList(m)
 							}
 						}
@@ -230,6 +234,9 @@ func (m model) updateSettingsTags(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.settingsMsg = fmt.Sprintf("Error: %v", err)
 				} else {
 					m.settingsMsg = fmt.Sprintf("Removed tag %q", removed)
+					if m.builder != nil {
+						_ = m.builder.LogEvent("credential-update", cred.Label, cred.Issuer, audit.Hostname(), true)
+					}
 					m = refreshCredList(m)
 					if m.settingsTagIdx > 0 {
 						m.settingsTagIdx--
@@ -506,6 +513,10 @@ func (m model) updateSettingsImport(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if err != nil {
 				m.settingsMsg = fmt.Sprintf("Import failed: %v", err)
 				return m, nil
+			}
+
+			if m.builder != nil && imported > 0 {
+				_ = m.builder.LogEvent("credential-import", "", "", audit.Hostname(), true)
 			}
 
 			if err := m.vaultMgr.Save(); err != nil {

--- a/cmd/tegata/tui_unlock.go
+++ b/cmd/tegata/tui_unlock.go
@@ -59,7 +59,7 @@ func unlockVaultCmd(path string, passphrase []byte) tea.Cmd {
 		builder, builderErr := newEventBuilder(cfg, filepath.Dir(path), passphrase)
 		if builderErr != nil {
 			// Non-fatal: TUI works without audit.
-			_, _ = fmt.Fprintf(os.Stderr, "tegata: audit unavailable: %v\n", builderErr)
+			_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit unavailable: %v\n", builderErr)
 		}
 
 		zeroBytes(passphrase)
@@ -105,11 +105,11 @@ func (m model) handleUnlockResult(msg unlockResultMsg) (tea.Model, tea.Cmd) {
 		mgr := m.vaultMgr
 		m.builder.OnHashStored = func(eventID, hashValue string) {
 			if err := mgr.SetAuditHash(eventID, hashValue); err != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "tegata: failed to store audit hash: %v\n", err)
+				_, _ = fmt.Fprintf(os.Stderr, "Warning: Failed to store audit hash: %v\n", err)
 			}
 		}
 		if logErr := m.builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+			_, _ = fmt.Fprintf(os.Stderr, "Warning: Audit log failed: %v\n", logErr)
 		}
 	}
 	m.passphraseInput.Blur()

--- a/cmd/tegata/tui_unlock.go
+++ b/cmd/tegata/tui_unlock.go
@@ -108,6 +108,9 @@ func (m model) handleUnlockResult(msg unlockResultMsg) (tea.Model, tea.Cmd) {
 				_, _ = fmt.Fprintf(os.Stderr, "tegata: failed to store audit hash: %v\n", err)
 			}
 		}
+		if logErr := m.builder.LogEvent("vault-unlock", "", "", audit.Hostname(), true); logErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata: audit log failed: %v\n", logErr)
+		}
 	}
 	m.passphraseInput.Blur()
 	m = loadCredentials(m)

--- a/cmd/tegata/ui.go
+++ b/cmd/tegata/ui.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+	"os/signal"
+	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -24,7 +26,20 @@ creation. If a vault exists, you will be prompted to unlock it.`,
 			m := initialModel(vaultPath)
 			// Do NOT redirect stdout before p.Run() (pitfall 3 from RESEARCH.md).
 			p := tea.NewProgram(m, tea.WithAltScreen())
+
+			// Forward SIGTERM and SIGHUP into the BubbleTea message loop so
+			// quit() runs normally and vault-lock is logged before exit.
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGHUP)
+			go func() {
+				if _, ok := <-sigCh; ok {
+					p.Send(sigTermMsg{})
+				}
+			}()
+
 			_, err := p.Run()
+			signal.Stop(sigCh)
+			close(sigCh)
 			return err
 		},
 	}

--- a/internal/audit/builder.go
+++ b/internal/audit/builder.go
@@ -31,6 +31,13 @@ type EventBuilder struct {
 	lastHash      string         // SHA-256 of the last successfully submitted event JSON
 	submitTimeout time.Duration  // timeout for submit operations (default 3s)
 	OnHashStored  func(eventID, hashValue string) // called after successful Submit to store hash in vault (D-15)
+	// LogVaultLockOnClose, when true, emits a vault-lock event just before the
+	// queue is saved and the builder is torn down. Set by setupAuditBuilder so
+	// CLI commands (which have no explicit quit path) automatically log the
+	// closing of a session without any per-command boilerplate.
+	// Leave false in the TUI: the TUI logs vault-lock explicitly before calling
+	// Close(), so setting this flag would produce a duplicate event.
+	LogVaultLockOnClose bool
 }
 
 // callSafe invokes fn, recovering any panic and logging it. Used for best-effort
@@ -213,10 +220,15 @@ func (b *EventBuilder) LogEvent(opType, label, service, host string, success boo
 }
 
 // Close saves the offline queue to disk. Should be called in a deferred
-// function in each auth command after LogEvent.
+// function in each auth command after LogEvent. When LogVaultLockOnClose is
+// true, a vault-lock event is emitted first so that CLI commands (which have
+// no explicit quit path) produce a matched unlock/lock pair in the audit log.
 func (b *EventBuilder) Close() error {
 	if b.disabled {
 		return nil
+	}
+	if b.LogVaultLockOnClose {
+		_ = b.LogEvent("vault-lock", "", "", Hostname(), true)
 	}
 	return b.queue.Save(b.queuePath)
 }

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -27,7 +27,8 @@ type AuthEvent struct {
 
 // HashString returns the lowercase hex-encoded SHA-256 digest of s. Used to
 // hash labels, service names, and host names before including them in audit
-// records.
+// records. The algorithm is mirrored by vault/manager.go:hashLabel for storing
+// deleted-label hashes in the vault payload — both must be kept in sync.
 func HashString(s string) string {
 	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:])

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -102,6 +102,10 @@ func FormatOperation(op string) string {
 		return "Credential remove"
 	case "credential-update":
 		return "Credential update"
+	case "credential-tag-update":
+		return "Credential tag update"
+	case "hotp-resync":
+		return "HOTP resync"
 	case "credential-import":
 		return "Credential import"
 	case "credential-export":

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -27,8 +27,8 @@ type AuthEvent struct {
 
 // HashString returns the lowercase hex-encoded SHA-256 digest of s. Used to
 // hash labels, service names, and host names before including them in audit
-// records. The algorithm is mirrored by vault/manager.go:hashLabel for storing
-// deleted-label hashes in the vault payload — both must be kept in sync.
+// records. vault/manager.go calls this function directly when storing
+// deleted-label hashes in the vault payload.
 func HashString(s string) string {
 	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:])

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -103,6 +103,10 @@ func FormatOperation(op string) string {
 		return "Credential update"
 	case "credential-import":
 		return "Credential import"
+	case "credential-export":
+		return "Credential export"
+	case "vault-passphrase-change":
+		return "Vault passphrase change"
 	default:
 		return op
 	}

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -33,6 +33,10 @@ func HashString(s string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// emptyLabelHash is the SHA-256 of an empty string, used as a sentinel to
+// identify events that have no associated credential (e.g. vault-unlock).
+var emptyLabelHash = HashString("")
+
 // BuildLabelMap creates a hash→label lookup table from a list of label strings.
 // This allows client-side resolution of label hashes back to human-readable
 // names without exposing plaintext labels in the audit ledger.
@@ -45,11 +49,31 @@ func BuildLabelMap(labels []string) map[string]string {
 }
 
 // ResolveLabel returns the human-readable label for a hash if found in the
-// lookup map, otherwise returns "(deleted)" to indicate the credential no
-// longer exists in the vault.
+// lookup map. Returns "—" for events with no associated credential (e.g.
+// vault-unlock), or "(deleted)" when the credential no longer exists.
 func ResolveLabel(labelHash string, labelMap map[string]string) string {
+	if labelHash == emptyLabelHash {
+		return "—"
+	}
 	if name, ok := labelMap[labelHash]; ok {
 		return name
+	}
+	return "(deleted)"
+}
+
+// ResolveLabelWithDeleted resolves a label hash using both the current label
+// map and a deleted-labels map. Returns "—" for events with no associated
+// credential, "Label (deleted)" for removed credentials, and "(deleted)" for
+// hashes with no record (e.g. entries predating this feature).
+func ResolveLabelWithDeleted(labelHash string, labelMap, deletedMap map[string]string) string {
+	if labelHash == emptyLabelHash {
+		return "—"
+	}
+	if name, ok := labelMap[labelHash]; ok {
+		return name
+	}
+	if name, ok := deletedMap[labelHash]; ok {
+		return name + " (deleted)"
 	}
 	return "(deleted)"
 }
@@ -67,6 +91,18 @@ func FormatOperation(op string) string {
 		return "Static password"
 	case "challenge-response":
 		return "Challenge-response"
+	case "vault-unlock":
+		return "Vault unlock"
+	case "vault-lock":
+		return "Vault lock"
+	case "credential-add":
+		return "Credential add"
+	case "credential-remove":
+		return "Credential remove"
+	case "credential-update":
+		return "Credential update"
+	case "credential-import":
+		return "Credential import"
 	default:
 		return op
 	}

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -37,9 +37,11 @@ func zeroBytes(b []byte) {
 	}
 }
 
-// hashLabel returns the lowercase hex-encoded SHA-256 digest of label,
-// matching the hash produced by audit.HashString so deleted-label hashes
-// align with what the audit ledger stores.
+// hashLabel returns the lowercase hex-encoded SHA-256 digest of label.
+// The algorithm is intentionally identical to audit.HashString — both functions
+// must be kept in sync so that deleted-label hashes stored here match the
+// hashes recorded in the audit ledger. If the hashing scheme ever changes,
+// update both functions together.
 func hashLabel(label string) string {
 	sum := sha256.Sum256([]byte(label))
 	return hex.EncodeToString(sum[:])

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -37,6 +37,14 @@ func zeroBytes(b []byte) {
 	}
 }
 
+// hashLabel returns the lowercase hex-encoded SHA-256 digest of label,
+// matching the hash produced by audit.HashString so deleted-label hashes
+// align with what the audit ledger stores.
+func hashLabel(label string) string {
+	sum := sha256.Sum256([]byte(label))
+	return hex.EncodeToString(sum[:])
+}
+
 // Manager provides access to an opened vault file. Call Unlock to decrypt the
 // payload before performing credential operations. Always defer Close to zero
 // sensitive memory.
@@ -429,7 +437,9 @@ func (m *Manager) AddCredential(cred model.Credential) (string, error) {
 	return cred.ID, nil
 }
 
-// RemoveCredential removes a credential by ID and saves.
+// RemoveCredential removes a credential by ID and saves. The credential's
+// label is retained in DeletedLabels so audit history can display "Label
+// (deleted)" rather than an unresolvable hash.
 func (m *Manager) RemoveCredential(id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -438,12 +448,32 @@ func (m *Manager) RemoveCredential(id string) error {
 	}
 	for i, c := range m.payload.Credentials {
 		if c.ID == id {
+			// Preserve label for audit history resolution before removing.
+			if m.payload.DeletedLabels == nil {
+				m.payload.DeletedLabels = make(map[string]string)
+			}
+			m.payload.DeletedLabels[hashLabel(c.Label)] = c.Label
 			m.payload.Credentials = append(m.payload.Credentials[:i], m.payload.Credentials[i+1:]...)
 			m.payload.ModifiedAt = time.Now().UTC()
 			return m.saveLocked()
 		}
 	}
 	return fmt.Errorf("credential %q: %w", id, errors.ErrNotFound)
+}
+
+// DeletedLabels returns a copy of the hash→label map for removed credentials.
+// Used by audit history display to resolve deleted credential labels.
+func (m *Manager) DeletedLabels() map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.payload == nil || m.payload.DeletedLabels == nil {
+		return nil
+	}
+	cp := make(map[string]string, len(m.payload.DeletedLabels))
+	for k, v := range m.payload.DeletedLabels {
+		cp[k] = v
+	}
+	return cp
 }
 
 // GetCredential returns the credential matching the given label (case-insensitive).

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/crypto"
 	"github.com/josh-wong/tegata/internal/crypto/guard"
 	"github.com/josh-wong/tegata/internal/errors"
@@ -35,16 +36,6 @@ func zeroBytes(b []byte) {
 	for i := range b {
 		b[i] = 0
 	}
-}
-
-// hashLabel returns the lowercase hex-encoded SHA-256 digest of label.
-// The algorithm is intentionally identical to audit.HashString — both functions
-// must be kept in sync so that deleted-label hashes stored here match the
-// hashes recorded in the audit ledger. If the hashing scheme ever changes,
-// update both functions together.
-func hashLabel(label string) string {
-	sum := sha256.Sum256([]byte(label))
-	return hex.EncodeToString(sum[:])
 }
 
 // Manager provides access to an opened vault file. Call Unlock to decrypt the
@@ -454,7 +445,7 @@ func (m *Manager) RemoveCredential(id string) error {
 			if m.payload.DeletedLabels == nil {
 				m.payload.DeletedLabels = make(map[string]string)
 			}
-			m.payload.DeletedLabels[hashLabel(c.Label)] = c.Label
+			m.payload.DeletedLabels[audit.HashString(c.Label)] = c.Label
 			m.payload.Credentials = append(m.payload.Credentials[:i], m.payload.Credentials[i+1:]...)
 			m.payload.ModifiedAt = time.Now().UTC()
 			return m.saveLocked()

--- a/pkg/model/vault.go
+++ b/pkg/model/vault.go
@@ -60,6 +60,9 @@ type VaultPayload struct {
 	// DeletedLabels maps labelHash → label for credentials that have been removed.
 	// Entries are never pruned; the map grows by one entry per removed credential
 	// so that audit history can display "Label (deleted)" indefinitely.
+	// TODO: Add a pruning strategy (e.g. remove entries whose hash appears in no
+	// audit record fetched within the last N months) to bound map growth for
+	// long-lived vaults with frequent credential rotation.
 	DeletedLabels map[string]string `json:"deleted_labels,omitempty"`
 }
 

--- a/pkg/model/vault.go
+++ b/pkg/model/vault.go
@@ -57,7 +57,10 @@ type VaultPayload struct {
 	RecoveryKeyHash string       `json:"recovery_key_hash"`
 	VaultID         string            `json:"vault_id,omitempty"`
 	AuditHashes     map[string]string `json:"audit_hashes,omitempty"`
-	DeletedLabels   map[string]string `json:"deleted_labels,omitempty"` // labelHash → label for removed credentials
+	// DeletedLabels maps labelHash → label for credentials that have been removed.
+	// Entries are never pruned; the map grows by one entry per removed credential
+	// so that audit history can display "Label (deleted)" indefinitely.
+	DeletedLabels map[string]string `json:"deleted_labels,omitempty"`
 }
 
 // VaultHeader represents the plaintext header of a vault file as specified in

--- a/pkg/model/vault.go
+++ b/pkg/model/vault.go
@@ -57,6 +57,7 @@ type VaultPayload struct {
 	RecoveryKeyHash string       `json:"recovery_key_hash"`
 	VaultID         string            `json:"vault_id,omitempty"`
 	AuditHashes     map[string]string `json:"audit_hashes,omitempty"`
+	DeletedLabels   map[string]string `json:"deleted_labels,omitempty"` // labelHash → label for removed credentials
 }
 
 // VaultHeader represents the plaintext header of a vault file as specified in


### PR DESCRIPTION
## Summary

This PR expands audit logging coverage to include vault lifecycle and credential management operations. Building on the existing audit logging foundation, it adds comprehensive event logging for ten critical operations: vault-unlock, vault-lock, credential-add, credential-remove, credential-tag-update, hotp-resync, credential-import, credential-export, vault-passphrase-change, and credential-add. The implementation includes hash-chain integrity verification, deleted credential label preservation, complete vault lifecycle logging across CLI/TUI/GUI, and fixes for timezone display and error handling.

## Related issues or PRs

Resolves #59

## Changes made

- Expanded audit logging to 10 distinct event types (vault-unlock, vault-lock, credential-add/remove/import/export, credential-tag-update, hotp-resync, vault-passphrase-change)
- Used distinct event types for HOTP counter resync (hotp-resync) and tag changes (credential-tag-update) instead of a generic credential-update; credential-update kept in FormatOperation for backwards compat with existing ledger records
- Implemented vault lifecycle events (unlock/lock) for complete session tracking across CLI, TUI, and GUI
- Added credential lifecycle events (add/remove/import/export) for complete audit trail coverage
- Implemented vault-passphrase-change event with special in-memory queue handling
- Extended FormatOperation() in internal/audit/event.go to format all event types
- Added DeletedLabels map to vault payload for preserving removed credential labels with audit history
- Implemented ResolveLabelWithDeleted() to display deleted credentials as "Label (deleted)" in history
- Fixed timezone display issue in history command (now shows local time instead of UTC)
- Fixed silent error suppression in change_passphrase.go audit builder initialization
- Applied grammatical consistency to warning messages across all command files

## Technical implementation

- **Approach:**
  - Event logging integrated into all credential management operations
  - Non-blocking async submission to ScalarDL Ledger with offline queue fallback
  - Hash-chain integrity verification using SHA-256
  - Privacy-preserving label hashing in audit events

- **Key components modified:**
  - internal/audit/builder.go: Added LogVaultLockOnClose flag; Close() emits vault-lock automatically for CLI commands
  - internal/audit/event.go: Added FormatOperation() cases, sentinel values, and new event type strings
  - pkg/model/vault.go: Added DeletedLabels field to VaultPayload
  - internal/vault/manager.go: Modified RemoveCredential() to preserve labels
  - cmd/tegata/helpers.go: setupAuditBuilder sets LogVaultLockOnClose so all CLI commands log vault-lock on exit
  - cmd/tegata/ui.go: SIGTERM/SIGHUP forwarded through BubbleTea message loop via sigTermMsg so quit() runs and vault-lock is logged
  - cmd/tegata/tui_model.go: sigTermMsg handler routes to quit()
  - cmd/tegata-gui/app.go: UnlockVault() logs vault-unlock; LockVault() logs vault-lock before teardown (covers idle timeout, user-triggered lock, and app shutdown)
  - cmd/tegata/history.go: Fixed timezone handling and deleted label resolution
  - cmd/tegata/tui*.go: Added vault lifecycle and credential events to TUI flows

- **Dependencies added/removed:** None

- **Design patterns used:**
  - Event sourcing for audit trail
  - Graceful degradation (audit events fail non-blocking)
  - Sentinel values (emptyLabelHash for operations without credentials)
  - In-memory queue fallback for operations invalidating disk-backed queue

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [x] Builds successfully on Windows (amd64)
- [x] Builds successfully on Linux (amd64)
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] CLI commands tested manually with expected inputs
- [x] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [x] ScalarDL integration tested (if applicable)
- [x] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [x] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [x] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes

## Additional context

This PR builds on the existing audit logging implementation to complete issue #59. The vault payload format changes to add DeletedLabels are backwards-compatible (empty map on legacy vaults). Audit history display now correctly shows local timestamps and preserves information about deleted credentials for audit completeness.

Vault lifecycle logging is now complete across all three surfaces: CLI commands log vault-unlock at start and vault-lock at exit via LogVaultLockOnClose; the TUI logs them on q/Ctrl+C, idle timeout, and SIGTERM/SIGHUP; the GUI logs them on unlock, user-triggered lock, idle timeout, and app shutdown.