### PR TITLE
Store HMAC secret in encrypted vault; remove plaintext HMAC secret

### DIFF
--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -215,13 +215,18 @@ func (a *App) UnlockVault(path, passphrase string) error {
 			return fmt.Errorf("migrating secret to vault: %w", vaultErr)
 		}
 		secretFromVault = a.config.Audit.SecretKey
-		a.config.Audit.SecretKey = ""
 
 		// Cleanup: rewrite tegata.toml to remove the plaintext secret_key field
 		// now that it has been safely stored in the vault.
 		if writeErr := config.WriteAuditSection(vaultDir(path), a.config.Audit); writeErr != nil {
+			// Migration failed at TOML write step; leave secretFromVault empty so
+			// the condition retries on next unlock (allowing the secret to stay in memory).
+			secretFromVault = ""
 			return fmt.Errorf("rewriting audit config to remove secret_key: %w", writeErr)
 		}
+
+		// Only zero the in-memory secret after both vault and TOML writes succeed.
+		a.config.Audit.SecretKey = ""
 	}
 
 	// Use the secret (from vault or after migration).

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -205,17 +205,27 @@ func (a *App) UnlockVault(path, passphrase string) error {
 
 	// Attempt to load HMAC secret from vault (encrypted storage).
 	secretFromVault := a.vault.GetSecret("audit.secret_key")
-	
-	// Migration: if secret is in tegata.toml but not in vault, move it to vault
-	// and clear it from memory (so it won't be rewritten to TOML on next save).
+
+	// Migration: if the vault doesn't have the secret but tegata.toml does,
+	// store it in the vault now.
 	if secretFromVault == "" && a.config.Audit.SecretKey != "" {
-		// Store in vault for future use.
 		if vaultErr := a.vault.SetSecret("audit.secret_key", a.config.Audit.SecretKey); vaultErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not migrate secret to vault: %v\n", vaultErr)
+		} else {
+			secretFromVault = a.config.Audit.SecretKey
 		}
-		secretFromVault = a.config.Audit.SecretKey
 	}
-	
+
+	// Cleanup: if tegata.toml still has secret_key (from before this fix was
+	// deployed, or written by the CLI), rewrite the file to remove it.
+	// This runs whenever the TOML contains the field, regardless of whether
+	// a vault migration was needed this session.
+	if a.config.Audit.SecretKey != "" {
+		if writeErr := config.WriteAuditSection(vaultDir(path), a.config.Audit); writeErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not rewrite audit config to remove secret_key: %v\n", writeErr)
+		}
+	}
+
 	// Use the secret (from vault or after migration).
 	if secretFromVault != "" {
 		a.config.Audit.SecretKey = secretFromVault
@@ -316,12 +326,27 @@ func (a *App) LockVault() {
 // by the audit setup. This ensures the HMAC secret key is not persisted to
 // disk after the app closes or the vault is locked.
 func (a *App) deleteClientProperties() {
-	if a.config.Audit.DockerComposePath == "" {
+	// Try to delete from the configured Docker compose location if available.
+	// DockerComposePath is a file path (e.g. .../docker/docker-compose.yml),
+	// so use its parent directory to locate the certs/ subdirectory.
+	if a.config.Audit.DockerComposePath != "" {
+		composeDir := filepath.Dir(a.config.Audit.DockerComposePath)
+		clientPropsPath := filepath.Join(composeDir, "certs", "client.properties")
+		if err := os.Remove(clientPropsPath); err != nil && !os.IsNotExist(err) {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not delete client.properties at %s: %v\n", clientPropsPath, err)
+		}
 		return
 	}
-	clientPropsPath := filepath.Join(a.config.Audit.DockerComposePath, "certs", "client.properties")
-	if err := os.Remove(clientPropsPath); err != nil && !os.IsNotExist(err) {
-		_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not delete client.properties: %v\n", err)
+	
+	// Fallback: check the default ~/.tegata/docker/certs/client.properties location
+	// in case DockerComposePath is not set (e.g., shutdown before any unlock).
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	defaultPath := filepath.Join(homeDir, ".tegata", "docker", "certs", "client.properties")
+	if err := os.Remove(defaultPath); err != nil && !os.IsNotExist(err) {
+		_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not delete client.properties at %s: %v\n", defaultPath, err)
 	}
 }
 

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -211,9 +211,11 @@ func (a *App) UnlockVault(path, passphrase string) error {
 	// to maintain consistency: either both succeed or both fail.
 	if secretFromVault == "" && a.config.Audit.SecretKey != "" {
 		if vaultErr := a.vault.SetSecret("audit.secret_key", a.config.Audit.SecretKey); vaultErr != nil {
+			a.config.Audit.SecretKey = ""
 			return fmt.Errorf("migrating secret to vault: %w", vaultErr)
 		}
 		secretFromVault = a.config.Audit.SecretKey
+		a.config.Audit.SecretKey = ""
 
 		// Cleanup: rewrite tegata.toml to remove the plaintext secret_key field
 		// now that it has been safely stored in the vault.

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -52,7 +52,7 @@ type App struct {
 	config       config.Config
 	clipboard    *clipboard.Manager
 	vaultPath    string
-	vaultModTime time.Time    // mtime of vault file at last read; used to detect external writes
+	vaultModTime time.Time     // mtime of vault file at last read; used to detect external writes
 	watcherStop  chan struct{} // closed to stop the vault file watcher goroutine
 	idleTimer    *IdleTimer
 	locked       bool
@@ -219,9 +219,6 @@ func (a *App) UnlockVault(path, passphrase string) error {
 		// Cleanup: rewrite tegata.toml to remove the plaintext secret_key field
 		// now that it has been safely stored in the vault.
 		if writeErr := config.WriteAuditSection(vaultDir(path), a.config.Audit); writeErr != nil {
-			// Migration failed at TOML write step; leave secretFromVault empty so
-			// the condition retries on next unlock (allowing the secret to stay in memory).
-			secretFromVault = ""
 			return fmt.Errorf("rewriting audit config to remove secret_key: %w", writeErr)
 		}
 
@@ -302,14 +299,14 @@ func (a *App) LockVault() {
 		a.idleTimer.Stop()
 	}
 	a.stopVaultWatcher()
-	
+
 	// Delete plaintext client.properties file when vault is locked.
 	// This ensures the HMAC secret is not accessible on disk after the app exits.
 	a.deleteClientProperties()
-	
+
 	// Zero the HMAC secret key from memory before closing the vault.
 	a.config.Audit.SecretKey = ""
-	
+
 	if a.vault != nil {
 		a.vault.Close()
 		a.vault = nil
@@ -340,7 +337,7 @@ func (a *App) deleteClientProperties() {
 		}
 		return
 	}
-	
+
 	// Fallback: check the default ~/.tegata/docker/certs/client.properties location
 	// in case DockerComposePath is not set (e.g., shutdown before any unlock).
 	homeDir, err := os.UserHomeDir()
@@ -1007,10 +1004,10 @@ type AuditHistoryRecord struct {
 
 // AuditVerifyResult is the JSON-serializable shape returned by VerifyAuditLog.
 type AuditVerifyResult struct {
-	Valid       bool     `json:"valid"`
-	EventCount  int      `json:"event_count"`
-	Skipped     int      `json:"skipped,omitempty"`
-	Faults      []string `json:"faults,omitempty"`
+	Valid      bool     `json:"valid"`
+	EventCount int      `json:"event_count"`
+	Skipped    int      `json:"skipped,omitempty"`
+	Faults     []string `json:"faults,omitempty"`
 }
 
 // IsAuditEnabled returns whether audit logging is configured and enabled.
@@ -1097,10 +1094,10 @@ func (a *App) VerifyCredentialAuditLog(label string) (*AuditVerifyResult, error)
 	}
 
 	return &AuditVerifyResult{
-		Valid:       result.Valid,
-		EventCount:  result.EventCount,
-		Skipped:     result.Skipped,
-		Faults:      result.Faults,
+		Valid:      result.Valid,
+		EventCount: result.EventCount,
+		Skipped:    result.Skipped,
+		Faults:     result.Faults,
 	}, nil
 }
 
@@ -1129,10 +1126,10 @@ func (a *App) VerifyAuditLog() (*AuditVerifyResult, error) {
 	}
 
 	return &AuditVerifyResult{
-		Valid:       result.Valid,
-		EventCount:  result.EventCount,
-		Skipped:     result.Skipped,
-		Faults:      result.Faults,
+		Valid:      result.Valid,
+		EventCount: result.EventCount,
+		Skipped:    result.Skipped,
+		Faults:     result.Faults,
 	}, nil
 }
 

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -207,22 +207,18 @@ func (a *App) UnlockVault(path, passphrase string) error {
 	secretFromVault := a.vault.GetSecret("audit.secret_key")
 
 	// Migration: if the vault doesn't have the secret but tegata.toml does,
-	// store it in the vault now.
+	// store it in the vault now. Only rewrite the TOML if vault migration succeeds
+	// to maintain consistency: either both succeed or both fail.
 	if secretFromVault == "" && a.config.Audit.SecretKey != "" {
 		if vaultErr := a.vault.SetSecret("audit.secret_key", a.config.Audit.SecretKey); vaultErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not migrate secret to vault: %v\n", vaultErr)
-		} else {
-			secretFromVault = a.config.Audit.SecretKey
+			return fmt.Errorf("migrating secret to vault: %w", vaultErr)
 		}
-	}
+		secretFromVault = a.config.Audit.SecretKey
 
-	// Cleanup: if tegata.toml still has secret_key (from before this fix was
-	// deployed, or written by the CLI), rewrite the file to remove it.
-	// This runs whenever the TOML contains the field, regardless of whether
-	// a vault migration was needed this session.
-	if a.config.Audit.SecretKey != "" {
+		// Cleanup: rewrite tegata.toml to remove the plaintext secret_key field
+		// now that it has been safely stored in the vault.
 		if writeErr := config.WriteAuditSection(vaultDir(path), a.config.Audit); writeErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not rewrite audit config to remove secret_key: %v\n", writeErr)
+			return fmt.Errorf("rewriting audit config to remove secret_key: %w", writeErr)
 		}
 	}
 
@@ -1191,17 +1187,20 @@ func (a *App) StartAuditServer() (map[string]interface{}, error) {
 	// registered and the ledger is confirmed reachable. Persisting tegata.toml
 	// and initialising the EventBuilder here ensures audit is active even if
 	// the contract-registration container is still running in the background.
+	// The secret is stored FIRST to ensure transactional consistency: if vault
+	// storage fails, the config file is not modified.
 	onRegistered := func(auditCfg config.AuditConfig) error {
-		if writeErr := config.WriteAuditSection(dir, auditCfg); writeErr != nil {
-			return fmt.Errorf("writing audit config: %w", writeErr)
-		}
-
 		// Store the HMAC secret in the encrypted vault instead of tegata.toml.
 		// This ensures the secret is never persisted in plaintext on disk.
+		// This must happen BEFORE writing the config file to maintain consistency.
 		if auditCfg.SecretKey != "" {
 			if vaultErr := a.vault.SetSecret("audit.secret_key", auditCfg.SecretKey); vaultErr != nil {
 				return fmt.Errorf("storing secret in vault: %w", vaultErr)
 			}
+		}
+
+		if writeErr := config.WriteAuditSection(dir, auditCfg); writeErr != nil {
+			return fmt.Errorf("writing audit config: %w", writeErr)
 		}
 
 		// Update in-memory config so auto-start fires on next unlock.

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -219,6 +219,7 @@ func (a *App) UnlockVault(path, passphrase string) error {
 		// Cleanup: rewrite tegata.toml to remove the plaintext secret_key field
 		// now that it has been safely stored in the vault.
 		if writeErr := config.WriteAuditSection(vaultDir(path), a.config.Audit); writeErr != nil {
+			a.config.Audit.SecretKey = ""
 			return fmt.Errorf("rewriting audit config to remove secret_key: %w", writeErr)
 		}
 

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -75,6 +75,7 @@ func (a *App) startup(ctx context.Context) {
 // shutdown is called by Wails when the application is closing. It locks the
 // vault to zero sensitive memory.
 func (a *App) shutdown(_ context.Context) {
+	a.deleteClientProperties()
 	a.LockVault()
 }
 
@@ -202,6 +203,24 @@ func (a *App) UnlockVault(path, passphrase string) error {
 	}
 	a.config = cfg
 
+	// Attempt to load HMAC secret from vault (encrypted storage).
+	secretFromVault := a.vault.GetSecret("audit.secret_key")
+	
+	// Migration: if secret is in tegata.toml but not in vault, move it to vault
+	// and clear it from memory (so it won't be rewritten to TOML on next save).
+	if secretFromVault == "" && a.config.Audit.SecretKey != "" {
+		// Store in vault for future use.
+		if vaultErr := a.vault.SetSecret("audit.secret_key", a.config.Audit.SecretKey); vaultErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not migrate secret to vault: %v\n", vaultErr)
+		}
+		secretFromVault = a.config.Audit.SecretKey
+	}
+	
+	// Use the secret (from vault or after migration).
+	if secretFromVault != "" {
+		a.config.Audit.SecretKey = secretFromVault
+	}
+
 	// Ensure the audit stack is running before building the EventBuilder so
 	// that the first credential operation after unlock records events
 	// immediately. EnsureStack is a no-op when DockerComposePath is empty or
@@ -270,6 +289,14 @@ func (a *App) LockVault() {
 		a.idleTimer.Stop()
 	}
 	a.stopVaultWatcher()
+	
+	// Delete plaintext client.properties file when vault is locked.
+	// This ensures the HMAC secret is not accessible on disk after the app exits.
+	a.deleteClientProperties()
+	
+	// Zero the HMAC secret key from memory before closing the vault.
+	a.config.Audit.SecretKey = ""
+	
 	if a.vault != nil {
 		a.vault.Close()
 		a.vault = nil
@@ -282,6 +309,19 @@ func (a *App) LockVault() {
 
 	if a.ctx != nil {
 		wailsruntime.EventsEmit(a.ctx, "vault:locked")
+	}
+}
+
+// deleteClientProperties removes the plaintext client.properties file created
+// by the audit setup. This ensures the HMAC secret key is not persisted to
+// disk after the app closes or the vault is locked.
+func (a *App) deleteClientProperties() {
+	if a.config.Audit.DockerComposePath == "" {
+		return
+	}
+	clientPropsPath := filepath.Join(a.config.Audit.DockerComposePath, "certs", "client.properties")
+	if err := os.Remove(clientPropsPath); err != nil && !os.IsNotExist(err) {
+		_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not delete client.properties: %v\n", err)
 	}
 }
 
@@ -1129,6 +1169,14 @@ func (a *App) StartAuditServer() (map[string]interface{}, error) {
 	onRegistered := func(auditCfg config.AuditConfig) error {
 		if writeErr := config.WriteAuditSection(dir, auditCfg); writeErr != nil {
 			return fmt.Errorf("writing audit config: %w", writeErr)
+		}
+
+		// Store the HMAC secret in the encrypted vault instead of tegata.toml.
+		// This ensures the secret is never persisted in plaintext on disk.
+		if auditCfg.SecretKey != "" {
+			if vaultErr := a.vault.SetSecret("audit.secret_key", auditCfg.SecretKey); vaultErr != nil {
+				return fmt.Errorf("storing secret in vault: %w", vaultErr)
+			}
 		}
 
 		// Update in-memory config so auto-start fires on next unlock.

--- a/cmd/tegata-gui/app_test.go
+++ b/cmd/tegata-gui/app_test.go
@@ -652,22 +652,24 @@ func TestUnlockVault_SecretZeroedAfterMigrationWriteError(t *testing.T) {
 	const testSecret = "hmac-secret-write-error-test"
 	writeTomlWithSecret(t, dir, testSecret)
 
-	// Create a subdirectory to ensure WriteAuditSection will fail when writing to tegata.toml.
-	// On Windows, directory-level Chmod doesn't reliably prevent file writes, so we make
-	// the directory itself read-only by creating it with restricted permissions.
-	// However, a more reliable cross-platform approach is to make the vault itself locked
-	// before attempting migration - but that would prevent the first SetSecret call.
-	// Instead, we skip this test on Windows where Chmod is unreliable.
+	// Make only tegata.toml read-only so that WriteAuditSection fails, while
+	// the vault file (vault.tegata) in the same directory remains writable so
+	// that SetSecret can persist the secret to the vault. This isolates the
+	// WriteAuditSection failure path in the migration logic.
+	//
+	// On Windows, file-level Chmod to read-only is supported but WriteFile
+	// behaviour on read-only files can be inconsistent across environments,
+	// so we skip there.
 	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on Windows: os.Chmod on directories is not reliable")
+		t.Skip("skipping test on Windows: os.Chmod on files is not reliable")
 	}
 
-	// Make the directory read-only so WriteAuditSection fails.
-	if err := os.Chmod(dir, 0o500); err != nil {
-		t.Fatalf("chmod dir: %v", err)
+	tomlPath := filepath.Join(dir, "tegata.toml")
+	if err := os.Chmod(tomlPath, 0o400); err != nil {
+		t.Fatalf("chmod tegata.toml: %v", err)
 	}
-	// Restore permissions so t.TempDir() cleanup can remove the directory.
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	// Restore permissions so t.TempDir() cleanup can remove the file.
+	t.Cleanup(func() { _ = os.Chmod(tomlPath, 0o600) })
 
 	app := NewApp()
 	err := app.UnlockVault(vaultPath, testPassphrase)

--- a/cmd/tegata-gui/app_test.go
+++ b/cmd/tegata-gui/app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -650,6 +651,16 @@ func TestUnlockVault_SecretZeroedAfterMigrationWriteError(t *testing.T) {
 
 	const testSecret = "hmac-secret-write-error-test"
 	writeTomlWithSecret(t, dir, testSecret)
+
+	// Create a subdirectory to ensure WriteAuditSection will fail when writing to tegata.toml.
+	// On Windows, directory-level Chmod doesn't reliably prevent file writes, so we make
+	// the directory itself read-only by creating it with restricted permissions.
+	// However, a more reliable cross-platform approach is to make the vault itself locked
+	// before attempting migration - but that would prevent the first SetSecret call.
+	// Instead, we skip this test on Windows where Chmod is unreliable.
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows: os.Chmod on directories is not reliable")
+	}
 
 	// Make the directory read-only so WriteAuditSection fails.
 	if err := os.Chmod(dir, 0o500); err != nil {

--- a/cmd/tegata-gui/app_test.go
+++ b/cmd/tegata-gui/app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/josh-wong/tegata/internal/audit"
@@ -561,5 +562,112 @@ func TestApp_SetIdleTimeoutSeconds_RejectsNegative(t *testing.T) {
 	app := NewApp()
 	if err := app.SetIdleTimeoutSeconds(-1); err == nil {
 		t.Fatal("expected error for negative idle timeout")
+	}
+}
+
+// writeTomlWithSecret writes a minimal tegata.toml containing a plaintext
+// secret_key to simulate a pre-migration config file.
+func writeTomlWithSecret(t *testing.T, dir, secret string) {
+	t.Helper()
+	content := "[audit]\nenabled = true\nsecret_key = \"" + secret + "\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "tegata.toml"), []byte(content), 0600); err != nil {
+		t.Fatalf("writing tegata.toml: %v", err)
+	}
+}
+
+// TestUnlockVault_MigratesSecretFromTOMLToVault verifies that when tegata.toml
+// contains a plaintext secret_key and the vault does not, UnlockVault migrates
+// the secret into the vault and removes it from the TOML file.
+func TestUnlockVault_MigratesSecretFromTOMLToVault(t *testing.T) {
+	vaultPath := setupTestVault(t)
+	dir := filepath.Dir(vaultPath)
+
+	const testSecret = "hmac-secret-for-migration-test"
+	writeTomlWithSecret(t, dir, testSecret)
+
+	app := NewApp()
+	if err := app.UnlockVault(vaultPath, testPassphrase); err != nil {
+		t.Fatalf("UnlockVault: %v", err)
+	}
+	defer app.LockVault()
+
+	// Secret should now be in the vault.
+	got := app.vault.GetSecret("audit.secret_key")
+	if got != testSecret {
+		t.Errorf("vault secret after migration: got %q, want %q", got, testSecret)
+	}
+
+	// Secret should be available on the in-memory config for use in this session.
+	if app.config.Audit.SecretKey != testSecret {
+		t.Errorf("in-memory SecretKey after migration: got %q, want %q", app.config.Audit.SecretKey, testSecret)
+	}
+
+	// TOML file should no longer contain secret_key.
+	data, err := os.ReadFile(filepath.Join(dir, "tegata.toml"))
+	if err != nil {
+		t.Fatalf("reading tegata.toml after migration: %v", err)
+	}
+	if strings.Contains(string(data), "secret_key") {
+		t.Error("tegata.toml still contains secret_key after migration")
+	}
+}
+
+// TestUnlockVault_MigrationIsIdempotent verifies that calling UnlockVault a
+// second time after migration succeeds and does not duplicate or corrupt data.
+func TestUnlockVault_MigrationIsIdempotent(t *testing.T) {
+	vaultPath := setupTestVault(t)
+	dir := filepath.Dir(vaultPath)
+
+	const testSecret = "hmac-secret-idempotent-test"
+	writeTomlWithSecret(t, dir, testSecret)
+
+	app := NewApp()
+
+	// First unlock triggers migration.
+	if err := app.UnlockVault(vaultPath, testPassphrase); err != nil {
+		t.Fatalf("first UnlockVault: %v", err)
+	}
+	app.LockVault()
+
+	// Second unlock should succeed without error (no secret_key in TOML now).
+	if err := app.UnlockVault(vaultPath, testPassphrase); err != nil {
+		t.Fatalf("second UnlockVault: %v", err)
+	}
+	defer app.LockVault()
+
+	// Secret should still be in the vault after the second unlock.
+	got := app.vault.GetSecret("audit.secret_key")
+	if got != testSecret {
+		t.Errorf("vault secret after second unlock: got %q, want %q", got, testSecret)
+	}
+}
+
+// TestUnlockVault_SecretZeroedAfterMigrationWriteError verifies that the
+// in-memory secret is zeroed if the TOML rewrite step of migration fails.
+func TestUnlockVault_SecretZeroedAfterMigrationWriteError(t *testing.T) {
+	vaultPath := setupTestVault(t)
+	dir := filepath.Dir(vaultPath)
+
+	const testSecret = "hmac-secret-write-error-test"
+	writeTomlWithSecret(t, dir, testSecret)
+
+	// Make the directory read-only so WriteAuditSection fails.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	// Restore permissions so t.TempDir() cleanup can remove the directory.
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	app := NewApp()
+	err := app.UnlockVault(vaultPath, testPassphrase)
+	// UnlockVault must fail because the TOML rewrite cannot proceed.
+	if err == nil {
+		app.LockVault()
+		t.Fatal("expected error when TOML rewrite fails, got nil")
+	}
+
+	// The in-memory secret must be zeroed even though an error was returned.
+	if app.config.Audit.SecretKey != "" {
+		t.Errorf("SecretKey not zeroed after migration error; got %q", app.config.Audit.SecretKey)
 	}
 }

--- a/cmd/tegata/helpers.go
+++ b/cmd/tegata/helpers.go
@@ -413,23 +413,24 @@ func unlockVaultForSecret(cmd *cobra.Command) (string, error) {
 	}
 
 	// Prompt for passphrase interactively, or use environment variable if set.
-	var passphrase string
+	// Always work with a byte slice so the passphrase can be zeroed after use.
+	var passBytes []byte
 	if envPass := os.Getenv("TEGATA_VAULT_PASSPHRASE"); envPass != "" {
-		passphrase = envPass
+		passBytes = []byte(envPass)
 	} else {
 		fmt.Fprint(os.Stderr, "Enter passphrase: ")
-		passBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+		var err error
+		passBytes, err = term.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return "", fmt.Errorf("reading passphrase: %w", err)
 		}
 		fmt.Fprintln(os.Stderr) // newline after password input
-		passphrase = string(passBytes)
-		defer func() {
-			for i := range passBytes {
-				passBytes[i] = 0
-			}
-		}()
 	}
+	defer func() {
+		for i := range passBytes {
+			passBytes[i] = 0
+		}
+	}()
 
 	// Open and unlock the vault.
 	mgr, err := vault.Open(vaultPath)
@@ -438,7 +439,7 @@ func unlockVaultForSecret(cmd *cobra.Command) (string, error) {
 	}
 	defer mgr.Close()
 
-	if err := mgr.Unlock([]byte(passphrase)); err != nil {
+	if err := mgr.Unlock(passBytes); err != nil {
 		return "", fmt.Errorf("unlocking vault: %w", err)
 	}
 

--- a/cmd/tegata/helpers.go
+++ b/cmd/tegata/helpers.go
@@ -402,3 +402,52 @@ func formatVaultPathWithBoldFilename(path string) string {
 	return "Vault: " + dir + separator + boldStyle.Render(filename)
 }
 
+// unlockVaultForSecret opens a vault and returns the HMAC secret from encrypted storage.
+// It uses interactive prompts for vault path and passphrase, with opt-in environment
+// variables for automation (TEGATA_VAULT_PATH and TEGATA_VAULT_PASSPHRASE).
+func unlockVaultForSecret(cmd *cobra.Command) (string, error) {
+	// Prompt for vault path if not provided via flag or env var.
+	vaultPath, err := resolveVaultPath(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	// Prompt for passphrase interactively, or use environment variable if set.
+	var passphrase string
+	if envPass := os.Getenv("TEGATA_VAULT_PASSPHRASE"); envPass != "" {
+		passphrase = envPass
+	} else {
+		fmt.Fprint(os.Stderr, "Enter passphrase: ")
+		passBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return "", fmt.Errorf("reading passphrase: %w", err)
+		}
+		fmt.Fprintln(os.Stderr) // newline after password input
+		passphrase = string(passBytes)
+		defer func() {
+			for i := range passBytes {
+				passBytes[i] = 0
+			}
+		}()
+	}
+
+	// Open and unlock the vault.
+	mgr, err := vault.Open(vaultPath)
+	if err != nil {
+		return "", fmt.Errorf("opening vault: %w", err)
+	}
+	defer mgr.Close()
+
+	if err := mgr.Unlock([]byte(passphrase)); err != nil {
+		return "", fmt.Errorf("unlocking vault: %w", err)
+	}
+
+	// Retrieve the secret from the vault.
+	secret := mgr.GetSecret("audit.secret_key")
+	if secret == "" {
+		return "", fmt.Errorf("HMAC secret not found in vault. Run 'tegata ledger setup' to register the secret")
+	}
+
+	return secret, nil
+}
+

--- a/cmd/tegata/ledger.go
+++ b/cmd/tegata/ledger.go
@@ -89,8 +89,15 @@ func runLedgerSetup(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
+	// Attempt to load secret_key from tegata.toml (old behavior for backward compatibility).
+	// If not present, prompt for vault unlock and load from encrypted vault storage.
 	if cfg.Audit.SecretKey == "" {
-		return fmt.Errorf("audit.secret_key is required in tegata.toml")
+		fmt.Fprintln(os.Stderr, "Secret key not found in tegata.toml. Loading from encrypted vault...")
+		secret, err := unlockVaultForSecret(cmd)
+		if err != nil {
+			return err
+		}
+		cfg.Audit.SecretKey = secret
 	}
 
 	// Dial the ScalarDL Ledger.

--- a/cmd/tegata/ledger.go
+++ b/cmd/tegata/ledger.go
@@ -17,14 +17,14 @@ import (
 )
 
 // auditTOMLExample is the canonical inline TOML block shown in help text and
-// error output. Defined once so both surfaces stay in sync.
+// error output. Defined once so both surfaces stay in sync. secret_key is
+// intentionally omitted — it is stored in the encrypted vault, not in tegata.toml.
 const auditTOMLExample = `  [audit]
   enabled           = true
   server            = "127.0.0.1:50051"
   privileged_server = "127.0.0.1:50052"
   entity_id         = "tegata-client"
   key_version       = 1
-  secret_key        = "your-secret-key"
   insecure          = true  # set to false for remote or production servers`
 
 // newLedgerCmd returns the 'tegata ledger' command with its subcommands.
@@ -185,8 +185,8 @@ func runLedgerStart(cmd *cobra.Command, _ []string) error {
 	}
 	dir := filepath.Dir(vaultPath)
 
-	// Get vault VaultID for entity ID derivation.
-	// We must open and unlock the vault to read the VaultID from the payload.
+	// Open and unlock the vault. Keep it open through SetupStack so we can
+	// store the generated HMAC secret in encrypted vault storage.
 	passphraseBytes, err := promptPassphrase("Vault passphrase: ")
 	if err != nil {
 		return fmt.Errorf("reading passphrase: %w", err)
@@ -201,9 +201,9 @@ func runLedgerStart(cmd *cobra.Command, _ []string) error {
 		mgr.Close()
 		return fmt.Errorf("unlocking vault: %w", err)
 	}
-	vaultID := mgr.VaultID()
 	zeroBytes(passphraseBytes)
-	mgr.Close()
+	vaultID := mgr.VaultID()
+	defer mgr.Close()
 
 	// Resolve compose directory: ~/.tegata/docker/
 	u, err := user.Current()
@@ -224,14 +224,22 @@ func runLedgerStart(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintln(os.Stderr, msg)
 	}
 
-	auditCfg, err := audit.SetupStack(bundleFS, composeDir, vaultID, progressFn, nil)
-	if err != nil {
-		return err
+	// onRegistered stores the generated HMAC secret in the encrypted vault and
+	// writes the [audit] section to tegata.toml (without secret_key).
+	onRegistered := func(auditCfg config.AuditConfig) error {
+		if auditCfg.SecretKey != "" {
+			if vaultErr := mgr.SetSecret("audit.secret_key", auditCfg.SecretKey); vaultErr != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not store secret in vault: %v\n", vaultErr)
+			}
+		}
+		if writeErr := config.WriteAuditSection(dir, auditCfg); writeErr != nil {
+			return fmt.Errorf("writing audit config: %w", writeErr)
+		}
+		return nil
 	}
 
-	// Write [audit] section to tegata.toml. Per D-03 step 8.
-	if err := config.WriteAuditSection(dir, auditCfg); err != nil {
-		return fmt.Errorf("writing audit config: %w", err)
+	if _, err := audit.SetupStack(bundleFS, composeDir, vaultID, progressFn, onRegistered); err != nil {
+		return err
 	}
 
 	fmt.Fprintln(os.Stderr, "Ledger server started. Audit logging is now active.")
@@ -291,6 +299,14 @@ func runLedgerStop(cmd *cobra.Command, _ []string) error {
 	if err := audit.StopStack(cfg.Audit.DockerComposePath); err != nil {
 		return err
 	}
+
+	// Delete the plaintext client.properties now that the stack is stopped.
+	composeDir := filepath.Dir(cfg.Audit.DockerComposePath)
+	clientPropsPath := filepath.Join(composeDir, "certs", "client.properties")
+	if err := os.Remove(clientPropsPath); err != nil && !os.IsNotExist(err) {
+		_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not delete client.properties: %v\n", err)
+	}
+
 	fmt.Fprintln(os.Stderr, "Ledger server stopped. Your audit history is preserved.")
 	return nil
 }

--- a/cmd/tegata/ledger.go
+++ b/cmd/tegata/ledger.go
@@ -99,6 +99,8 @@ func runLedgerSetup(cmd *cobra.Command, _ []string) error {
 		}
 		cfg.Audit.SecretKey = secret
 	}
+	// Zero the secret on all exit paths regardless of success or failure.
+	defer func() { cfg.Audit.SecretKey = "" }()
 
 	// Dial the ScalarDL Ledger.
 	fmt.Fprintf(os.Stderr, "Connecting to ScalarDL Ledger at %s (privileged: %s)...\n",

--- a/cmd/tegata/ledger.go
+++ b/cmd/tegata/ledger.go
@@ -226,10 +226,12 @@ func runLedgerStart(cmd *cobra.Command, _ []string) error {
 
 	// onRegistered stores the generated HMAC secret in the encrypted vault and
 	// writes the [audit] section to tegata.toml (without secret_key).
+	// The secret is stored FIRST to ensure transactional consistency: if vault
+	// storage fails, the config file is not modified.
 	onRegistered := func(auditCfg config.AuditConfig) error {
 		if auditCfg.SecretKey != "" {
 			if vaultErr := mgr.SetSecret("audit.secret_key", auditCfg.SecretKey); vaultErr != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not store secret in vault: %v\n", vaultErr)
+				return fmt.Errorf("storing HMAC secret in vault: %w", vaultErr)
 			}
 		}
 		if writeErr := config.WriteAuditSection(dir, auditCfg); writeErr != nil {

--- a/docs/scalardl-setup.md
+++ b/docs/scalardl-setup.md
@@ -216,7 +216,6 @@ server            = "127.0.0.1:50051"
 privileged_server = "127.0.0.1:50052"
 entity_id         = "tegata-client"
 key_version       = 1
-secret_key        = "your-32-byte-hex-secret-key-here"
 insecure          = true
 auto_start        = false
 ```
@@ -230,18 +229,27 @@ server            = "scalardl.example.com:50051"
 privileged_server = "scalardl.example.com:50052"
 entity_id         = "tegata-client"
 key_version       = 1
-secret_key        = "your-32-byte-hex-secret-key-here"
 # insecure        = false  # Default; TLS is enabled. You can omit this field for remote or production servers.
 auto_start        = false
 ```
 
 Set `auto_start = false` when managing ScalarDL yourself (locally or remotely). Tegata connects to the audit server automatically when needed — `auto_start` only controls whether Tegata starts a local Docker stack on vault unlock, which applies to the bundled one-click setup only.
 
+The `secret_key` is not set in `tegata.toml`. It is stored in the encrypted vault. When you run `tegata ledger setup`, Tegata prompts for your vault passphrase and loads the secret automatically.
+
 Then run `tegata ledger setup` to register your credentials.
 
 ```bash
 tegata ledger setup --vault /path/to/vault
 ```
+
+Tegata prompts for your vault passphrase and loads the HMAC secret from encrypted vault storage. For automated environments (such as CI), you can set the passphrase via environment variable.
+
+```bash
+TEGATA_VAULT_PASSPHRASE=your-passphrase tegata ledger setup --vault /path/to/vault
+```
+
+> **Note:** Only use `TEGATA_VAULT_PASSPHRASE` in trusted automated environments. Never commit passphrases to version control.
 
 ## Troubleshooting
 
@@ -264,7 +272,7 @@ If this fails with `INVALID_SIGNATURE`, verify that the secret key in `certs/cli
 
 ### The request signature cannot be validated
 
-This error (`DL-COMMON-400003`) means the HMAC secret key used for signing does not match the secret registered with the ledger. Run `tegata config show` to check the configured `secret_key`. If you changed the secret after the initial registration, tear down the stack completely and re-run setup.
+This error (`DL-COMMON-400003`) means the HMAC secret key used for signing does not match the secret registered with the ledger. The secret is stored in your encrypted vault. If you changed the secret after the initial registration, tear down the stack completely and re-run setup.
 
 ```bash
 docker compose -f ~/.tegata/docker/docker-compose.yml down -v

--- a/internal/config/write_audit.go
+++ b/internal/config/write_audit.go
@@ -24,6 +24,8 @@ func WriteAuditSection(dir string, cfg AuditConfig) error {
 }
 
 // formatAuditSection renders the [audit] TOML block from cfg.
+// Note: secret_key is omitted since it is stored encrypted in the vault,
+// not in plaintext tegata.toml.
 func formatAuditSection(cfg AuditConfig) string {
 	var buf bytes.Buffer
 	buf.WriteString("[audit]\n")
@@ -39,9 +41,6 @@ func formatAuditSection(cfg AuditConfig) string {
 	}
 	if cfg.KeyVersion > 0 {
 		buf.WriteString(fmt.Sprintf("key_version = %d\n", cfg.KeyVersion))
-	}
-	if cfg.SecretKey != "" {
-		buf.WriteString(fmt.Sprintf("secret_key = %q\n", cfg.SecretKey))
 	}
 	if cfg.Insecure {
 		buf.WriteString("insecure = true\n")

--- a/internal/config/write_audit_test.go
+++ b/internal/config/write_audit_test.go
@@ -33,6 +33,9 @@ func TestWriteAuditSection_NewFile(t *testing.T) {
 	if !strings.Contains(content, "tegata-a3f2c810") {
 		t.Error("written file does not contain entity_id value")
 	}
+	if strings.Contains(content, "secret_key") {
+		t.Error("written file should NOT contain secret_key (should be stored in vault)")
+	}
 }
 
 func TestWriteAuditSection_Append(t *testing.T) {
@@ -130,6 +133,11 @@ func TestDockerComposePath_RoundTrip(t *testing.T) {
 	if loaded.Audit.DockerComposePath != cfg.DockerComposePath {
 		t.Errorf("DockerComposePath round-trip: got %q, want %q",
 			loaded.Audit.DockerComposePath, cfg.DockerComposePath)
+	}
+	// Secret key is not persisted to tegata.toml (it's stored in the vault).
+	// After writing and reloading, it should be empty.
+	if loaded.Audit.SecretKey != "" {
+		t.Errorf("SecretKey should not persist through TOML write/load; got %q", loaded.Audit.SecretKey)
 	}
 }
 

--- a/internal/vault/manager.go
+++ b/internal/vault/manager.go
@@ -49,6 +49,10 @@ func clearPayload(p *model.VaultPayload) {
 	for i := range p.Credentials {
 		p.Credentials[i].Secret = ""
 	}
+	for k := range p.Secrets {
+		p.Secrets[k] = ""
+		delete(p.Secrets, k)
+	}
 }
 
 // Manager provides access to an opened vault file. Call Unlock to decrypt the
@@ -982,6 +986,32 @@ func ZeroAuditHashes(m map[string]string) {
 		m[k] = ""
 		delete(m, k)
 	}
+}
+
+// GetSecret retrieves an auxiliary secret stored in the vault (e.g., HMAC key).
+// Returns an empty string if the vault is locked or the secret does not exist.
+func (m *Manager) GetSecret(key string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.payload == nil || m.payload.Secrets == nil {
+		return ""
+	}
+	return m.payload.Secrets[key]
+}
+
+// SetSecret stores an auxiliary secret in the vault (e.g., HMAC key).
+// The secret is encrypted with the vault's data encryption key and persisted to disk.
+func (m *Manager) SetSecret(key, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.payload == nil {
+		return fmt.Errorf("vault not unlocked: %w", errors.ErrVaultLocked)
+	}
+	if m.payload.Secrets == nil {
+		m.payload.Secrets = make(map[string]string)
+	}
+	m.payload.Secrets[key] = value
+	return m.saveLocked()
 }
 
 // atomicWrite writes data to path using temp-file-rename for crash safety.

--- a/internal/vault/secrets_test.go
+++ b/internal/vault/secrets_test.go
@@ -1,0 +1,118 @@
+package vault
+
+import (
+"testing"
+
+"github.com/josh-wong/tegata/internal/crypto"
+)
+
+func TestManager_GetSetSecret(t *testing.T) {
+tmpDir := t.TempDir()
+path := tmpDir + "/test.vault"
+passphrase := []byte("test-passphrase-1234567890")
+
+// Create a new vault.
+_, err := Create(path, passphrase, crypto.DefaultParams)
+if err != nil {
+t.Fatalf("Create failed: %v", err)
+}
+
+// Open and unlock the vault.
+mgr, err := Open(path)
+if err != nil {
+t.Fatalf("Open failed: %v", err)
+}
+defer mgr.Close()
+
+if err := mgr.Unlock(passphrase); err != nil {
+t.Fatalf("Unlock failed: %v", err)
+}
+
+// Test SetSecret and GetSecret.
+testSecret := "test-hmac-secret-key-1234567890"
+if err := mgr.SetSecret("audit.secret_key", testSecret); err != nil {
+t.Fatalf("SetSecret failed: %v", err)
+}
+
+retrieved := mgr.GetSecret("audit.secret_key")
+if retrieved != testSecret {
+t.Errorf("GetSecret returned %q, want %q", retrieved, testSecret)
+}
+
+// Close and reopen to verify persistence.
+mgr.Close()
+
+mgr2, err := Open(path)
+if err != nil {
+t.Fatalf("Open (second) failed: %v", err)
+}
+defer mgr2.Close()
+
+if err := mgr2.Unlock(passphrase); err != nil {
+t.Fatalf("Unlock (second) failed: %v", err)
+}
+
+retrieved2 := mgr2.GetSecret("audit.secret_key")
+if retrieved2 != testSecret {
+t.Errorf("GetSecret (after reopen) returned %q, want %q", retrieved2, testSecret)
+}
+}
+
+func TestManager_GetSecret_Locked(t *testing.T) {
+tmpDir := t.TempDir()
+path := tmpDir + "/test.vault"
+passphrase := []byte("test-passphrase-1234567890")
+
+// Create and unlock a vault.
+_, err := Create(path, passphrase, crypto.DefaultParams)
+if err != nil {
+t.Fatalf("Create failed: %v", err)
+}
+
+mgr, err := Open(path)
+if err != nil {
+t.Fatalf("Open failed: %v", err)
+}
+defer mgr.Close()
+
+if err := mgr.Unlock(passphrase); err != nil {
+t.Fatalf("Unlock failed: %v", err)
+}
+
+if err := mgr.SetSecret("audit.secret_key", "test-secret"); err != nil {
+t.Fatalf("SetSecret failed: %v", err)
+}
+
+// Close the vault (locks it).
+mgr.Close()
+
+// Try to get secret from locked vault (should return empty string).
+result := mgr.GetSecret("audit.secret_key")
+if result != "" {
+t.Errorf("GetSecret on locked vault returned %q, want empty string", result)
+}
+}
+
+func TestManager_SetSecret_Locked(t *testing.T) {
+tmpDir := t.TempDir()
+path := tmpDir + "/test.vault"
+passphrase := []byte("test-passphrase-1234567890")
+
+// Create a vault but don't unlock it.
+_, err := Create(path, passphrase, crypto.DefaultParams)
+if err != nil {
+t.Fatalf("Create failed: %v", err)
+}
+
+mgr, err := Open(path)
+if err != nil {
+t.Fatalf("Open failed: %v", err)
+}
+defer mgr.Close()
+
+// Try to set secret on locked vault (should return error).
+err = mgr.SetSecret("audit.secret_key", "test-secret")
+if err == nil {
+t.Error("SetSecret on locked vault should have returned an error")
+}
+}

--- a/internal/vault/secrets_test.go
+++ b/internal/vault/secrets_test.go
@@ -1,118 +1,118 @@
 package vault
 
 import (
-"testing"
+	"testing"
 
-"github.com/josh-wong/tegata/internal/crypto"
+	"github.com/josh-wong/tegata/internal/crypto"
 )
 
 func TestManager_GetSetSecret(t *testing.T) {
-tmpDir := t.TempDir()
-path := tmpDir + "/test.vault"
-passphrase := []byte("test-passphrase-1234567890")
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test.vault"
+	passphrase := []byte("test-passphrase-1234567890")
 
-// Create a new vault.
-_, err := Create(path, passphrase, crypto.DefaultParams)
-if err != nil {
-t.Fatalf("Create failed: %v", err)
-}
+	// Create a new vault.
+	_, err := Create(path, passphrase, crypto.DefaultParams)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
 
-// Open and unlock the vault.
-mgr, err := Open(path)
-if err != nil {
-t.Fatalf("Open failed: %v", err)
-}
-defer mgr.Close()
+	// Open and unlock the vault.
+	mgr, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer mgr.Close()
 
-if err := mgr.Unlock(passphrase); err != nil {
-t.Fatalf("Unlock failed: %v", err)
-}
+	if err := mgr.Unlock(passphrase); err != nil {
+		t.Fatalf("Unlock failed: %v", err)
+	}
 
-// Test SetSecret and GetSecret.
-testSecret := "test-hmac-secret-key-1234567890"
-if err := mgr.SetSecret("audit.secret_key", testSecret); err != nil {
-t.Fatalf("SetSecret failed: %v", err)
-}
+	// Test SetSecret and GetSecret.
+	testSecret := "test-hmac-secret-key-1234567890"
+	if err := mgr.SetSecret("audit.secret_key", testSecret); err != nil {
+		t.Fatalf("SetSecret failed: %v", err)
+	}
 
-retrieved := mgr.GetSecret("audit.secret_key")
-if retrieved != testSecret {
-t.Errorf("GetSecret returned %q, want %q", retrieved, testSecret)
-}
+	retrieved := mgr.GetSecret("audit.secret_key")
+	if retrieved != testSecret {
+		t.Errorf("GetSecret returned %q, want %q", retrieved, testSecret)
+	}
 
-// Close and reopen to verify persistence.
-mgr.Close()
+	// Close and reopen to verify persistence.
+	mgr.Close()
 
-mgr2, err := Open(path)
-if err != nil {
-t.Fatalf("Open (second) failed: %v", err)
-}
-defer mgr2.Close()
+	mgr2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open (second) failed: %v", err)
+	}
+	defer mgr2.Close()
 
-if err := mgr2.Unlock(passphrase); err != nil {
-t.Fatalf("Unlock (second) failed: %v", err)
-}
+	if err := mgr2.Unlock(passphrase); err != nil {
+		t.Fatalf("Unlock (second) failed: %v", err)
+	}
 
-retrieved2 := mgr2.GetSecret("audit.secret_key")
-if retrieved2 != testSecret {
-t.Errorf("GetSecret (after reopen) returned %q, want %q", retrieved2, testSecret)
-}
+	retrieved2 := mgr2.GetSecret("audit.secret_key")
+	if retrieved2 != testSecret {
+		t.Errorf("GetSecret (after reopen) returned %q, want %q", retrieved2, testSecret)
+	}
 }
 
 func TestManager_GetSecret_Locked(t *testing.T) {
-tmpDir := t.TempDir()
-path := tmpDir + "/test.vault"
-passphrase := []byte("test-passphrase-1234567890")
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test.vault"
+	passphrase := []byte("test-passphrase-1234567890")
 
-// Create and unlock a vault.
-_, err := Create(path, passphrase, crypto.DefaultParams)
-if err != nil {
-t.Fatalf("Create failed: %v", err)
-}
+	// Create and unlock a vault.
+	_, err := Create(path, passphrase, crypto.DefaultParams)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
 
-mgr, err := Open(path)
-if err != nil {
-t.Fatalf("Open failed: %v", err)
-}
-defer mgr.Close()
+	mgr, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer mgr.Close()
 
-if err := mgr.Unlock(passphrase); err != nil {
-t.Fatalf("Unlock failed: %v", err)
-}
+	if err := mgr.Unlock(passphrase); err != nil {
+		t.Fatalf("Unlock failed: %v", err)
+	}
 
-if err := mgr.SetSecret("audit.secret_key", "test-secret"); err != nil {
-t.Fatalf("SetSecret failed: %v", err)
-}
+	if err := mgr.SetSecret("audit.secret_key", "test-secret"); err != nil {
+		t.Fatalf("SetSecret failed: %v", err)
+	}
 
-// Close the vault (locks it).
-mgr.Close()
+	// Close the vault (locks it).
+	mgr.Close()
 
-// Try to get secret from locked vault (should return empty string).
-result := mgr.GetSecret("audit.secret_key")
-if result != "" {
-t.Errorf("GetSecret on locked vault returned %q, want empty string", result)
-}
+	// Try to get secret from locked vault (should return empty string).
+	result := mgr.GetSecret("audit.secret_key")
+	if result != "" {
+		t.Errorf("GetSecret on locked vault returned %q, want empty string", result)
+	}
 }
 
 func TestManager_SetSecret_Locked(t *testing.T) {
-tmpDir := t.TempDir()
-path := tmpDir + "/test.vault"
-passphrase := []byte("test-passphrase-1234567890")
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test.vault"
+	passphrase := []byte("test-passphrase-1234567890")
 
-// Create a vault but don't unlock it.
-_, err := Create(path, passphrase, crypto.DefaultParams)
-if err != nil {
-t.Fatalf("Create failed: %v", err)
-}
+	// Create a vault but don't unlock it.
+	_, err := Create(path, passphrase, crypto.DefaultParams)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
 
-mgr, err := Open(path)
-if err != nil {
-t.Fatalf("Open failed: %v", err)
-}
-defer mgr.Close()
+	mgr, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer mgr.Close()
 
-// Try to set secret on locked vault (should return error).
-err = mgr.SetSecret("audit.secret_key", "test-secret")
-if err == nil {
-t.Error("SetSecret on locked vault should have returned an error")
-}
+	// Try to set secret on locked vault (should return error).
+	err = mgr.SetSecret("audit.secret_key", "test-secret")
+	if err == nil {
+		t.Error("SetSecret on locked vault should have returned an error")
+	}
 }

--- a/pkg/model/vault.go
+++ b/pkg/model/vault.go
@@ -65,6 +65,9 @@ type VaultPayload struct {
 	// audit record fetched within the last N months) to bound map growth for
 	// long-lived vaults with frequent credential rotation.
 	DeletedLabels map[string]string `json:"deleted_labels,omitempty"`
+	// Secrets stores auxiliary secrets such as the HMAC secret for ScalarDL Ledger.
+	// These are stored encrypted in the vault and never persisted to tegata.toml.
+	Secrets map[string]string `json:"secrets,omitempty"`
 }
 
 // VaultHeader represents the plaintext header of a vault file as specified in


### PR DESCRIPTION
## Summary

This PR moves the HMAC secret out of plaintext configuration and into the encrypted vault. It stops writing `secret_key` to tegata.toml, migrates an existing secret into the vault on unlock/setup, deletes plaintext `client.properties` on GUI/CLI shutdown, and updates documentation and tests.

## Related issues or PRs

Resolves #53

## Changes made

- internal/vault/manager.go: add Secrets map, GetSecret, SetSecret, and zero secrets in clearPayload
- cmd/tegata-gui/app.go: migrate secret on UnlockVault; always rewrite TOML without `secret_key`; delete client.properties on shutdown; store secret from StartAuditServer callback
- cmd/tegata/ledger.go: keep vault open through ledger start/setup; persist generated HMAC secret in vault via onRegistered callback; delete client.properties in ledger stop; remove `secret_key` from auditTOMLExample
- cmd/tegata/helpers.go: add unlockVaultForSecret() helper (supports TEGATA_VAULT_PASSPHRASE env var)
- internal/config/write_audit.go: do not write `secret_key` to tegata.toml
- docs/scalardl-setup.md: remove `secret_key` from examples; document vault usage and TEGATA_VAULT_PASSPHRASE
- tests: update/add tests for vault secret API and TOML audit behavior

## Technical implementation

- **Approach:** Read `secret_key` from tegata.toml for migration only; store and read HMAC secrets exclusively from the encrypted vault going forward. When Unlock/Start sees a `secret_key` in the TOML it migrates the secret into the vault and rewrites the TOML without `secret_key`. For new setups, ledger start/init will create and persist the secret into the vault via the onRegistered callback. GUI and CLI both delete the Docker `certs/client.properties` plaintext file after the stack stops.

- **Key components modified:** internal/vault (vault manager API), cmd/tegata-gui, cmd/tegata (ledger commands), internal/config, docs

- **Dependencies added/removed:** none

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [x] Builds successfully on Windows (amd64)
- [ ] Builds successfully on Linux (amd64)
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] CLI commands tested manually with expected inputs
- [x] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [x] Cryptographic operations verified (if applicable)
- [ ] ScalarDL integration tested (if applicable)
- [ ] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [ ] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [ ] Dependencies pinned to specific versions
- [x] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## Additional context

- Migration behavior: if a `secret_key` exists in tegata.toml it will be moved into the encrypted vault on unlock/setup and the TOML will be rewritten without the `secret_key` to avoid storing secrets in plaintext.

- Automation: `TEGATA_VAULT_PASSPHRASE` environment variable is supported for non-interactive workflows. Avoid using this on shared machines or storing it in VCS.

- Note: Ledger container registration may time out in environments where ScalarDL services are not reachable; that is an infrastructure issue and does not affect the vault-based secret storage correctness.

PR prepared by automation. Please review the Changes made and Testing performed sections and request changes as needed.
