### PR TITLE
Fix audit secret not loaded from vault on GUI unlock

### DIFF
--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -250,7 +250,8 @@ func (a *App) UnlockVault(path, passphrase string) error {
 	}
 
 	// Build EventBuilder while passphrase is available (AUDT-02).
-	builder, builderErr := a.buildEventBuilder(cfg, path, passBytes)
+	// Use a.config (not cfg) so the SecretKey loaded from the vault is included.
+	builder, builderErr := a.buildEventBuilder(a.config, path, passBytes)
 	if builderErr != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: audit unavailable: %v\n", builderErr)
 	}

--- a/cmd/tegata/ledger.go
+++ b/cmd/tegata/ledger.go
@@ -179,11 +179,6 @@ func runLedgerSetup(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("storing secret in vault: %w", err)
 	}
 
-	// Persist the secret to disk
-	if err := mgr.Save(); err != nil {
-		return fmt.Errorf("saving vault after storing secret: %w", err)
-	}
-
 	fmt.Fprintln(os.Stderr, "Generic contracts verified. Audit setup complete.")
 	return nil
 }

--- a/cmd/tegata/ledger.go
+++ b/cmd/tegata/ledger.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"golang.org/x/term"
+
 	"github.com/josh-wong/tegata/internal/audit"
 	"github.com/josh-wong/tegata/internal/config"
 	tegerrors "github.com/josh-wong/tegata/internal/errors"
@@ -145,6 +147,43 @@ func runLedgerSetup(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintln(os.Stderr, "certs/client.properties is on a single unbroken line with no line breaks in the value.")
 		return fmt.Errorf("contract verification failed: %w", err)
 	}
+
+	// Store the secret in the vault's encrypted storage so the GUI can retrieve it on unlock.
+	// This ensures that even after ledger database resets, the secret persists in the vault.
+	fmt.Fprintln(os.Stderr, "Storing secret in vault...")
+	mgr, err := vault.Open(vaultPath)
+	if err != nil {
+		return fmt.Errorf("opening vault to store secret: %w", err)
+	}
+	defer mgr.Close()
+
+	if err := mgr.Unlock([]byte(os.Getenv("TEGATA_VAULT_PASSPHRASE"))); err != nil {
+		// If TEGATA_VAULT_PASSPHRASE is not set, prompt the user.
+		fmt.Fprint(os.Stderr, "Enter passphrase to save secret in vault: ")
+		passBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return fmt.Errorf("reading passphrase: %w", err)
+		}
+		fmt.Fprintln(os.Stderr)
+		defer func() {
+			for i := range passBytes {
+				passBytes[i] = 0
+			}
+		}()
+		if err := mgr.Unlock(passBytes); err != nil {
+			return fmt.Errorf("unlocking vault: %w", err)
+		}
+	}
+
+	if err := mgr.SetSecret("audit.secret_key", cfg.Audit.SecretKey); err != nil {
+		return fmt.Errorf("storing secret in vault: %w", err)
+	}
+
+	// Persist the secret to disk
+	if err := mgr.Save(); err != nil {
+		return fmt.Errorf("saving vault after storing secret: %w", err)
+	}
+
 	fmt.Fprintln(os.Stderr, "Generic contracts verified. Audit setup complete.")
 	return nil
 }


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where audit events were silently dropped after running `ledger setup`. The root cause was a variable shadowing bug in the GUI's vault unlock flow combined with incomplete secret persistence in the ledger setup command.

## Related issues or PRs

Bug was introduced in #86 

## Changes made

- **cmd/tegata-gui/app.go (line 256)**: Pass `a.config` (not local `cfg`) to `buildEventBuilder` so the vault-loaded SecretKey is included when building the audit client
- **cmd/tegata/ledger.go (lines 147-185)**: After contract verification in `ledger setup`, explicitly persist the registered secret back to the encrypted vault to ensure it survives ledger DB resets

## Technical implementation

- **Approach**: Fixed variable shadowing where `cfg` was loaded before vault unlock, so `SecretKey` was always empty when building the audit client. Use `a.config` instead, which has the secret injected at line 235. Also ensure `ledger setup` persists the secret to vault after registration.
- **Key components modified**: `App.UnlockVault()` in app.go, `runLedgerSetup()` in ledger.go
- **Dependencies added**: `golang.org/x/term` (for password input without echo)
- **Design patterns used**: Follows existing vault unlock/lock pattern

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [x] Builds successfully on Windows (amd64)
- [ ] Builds successfully on Linux (amd64)
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable) — not applicable, no new integrations
- [x] CLI commands tested manually with expected inputs
- [x] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [x] Cryptographic operations verified (if applicable)
- [x] ScalarDL integration tested (if applicable)
- [ ] Cross-platform compatibility verified (if applicable) — not applicable, Darwin only

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [x] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [x] Documentation updated (README, user guides, API docs if applicable) — not applicable, no user-facing changes

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## Additional context

This bug was discovered during manual testing of #52 (Docker shutdown) and was mistakenly introduced in #86 during manual testing (creating multiple vaults that overwrote existing vaults). After running `ledger setup` and generating a TOTP code in the GUI, audit events never appeared in the GUI's audit history or in the ScalarDL ledger. Investigation revealed two issues: (1) GUI was building the audit client with an empty SecretKey due to passing stale `cfg` instead of `a.config`, and (2) `ledger setup` wasn't persisting the secret to the vault after registration, so after ledger DB resets the secret wasn't available. Both are now fixed.
