### PR TITLE
Stop Docker audit stack when quitting the TUI

### DIFF
--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -390,6 +390,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				_ = m.builder.Close()
 				m.builder = nil
 			}
+			// Delete plaintext client.properties on idle lock to ensure the
+			// HMAC secret is not accessible on disk while the vault is locked.
+			m.deleteClientProperties()
 			if m.vaultMgr != nil {
 				m.vaultMgr.Close()
 				m.vaultMgr = nil
@@ -552,15 +555,39 @@ func (m model) quit() (tea.Model, tea.Cmd) {
 		if err := audit.StopStack(m.cfg.Audit.DockerComposePath); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Warning: could not stop audit server: %v\n", err)
 		}
-		// Delete the plaintext client.properties now that the stack is stopped.
+	}
+	// Delete the plaintext client.properties now that the stack is stopped.
+	m.deleteClientProperties()
+
+	return m, tea.Quit
+}
+
+// deleteClientProperties removes the plaintext client.properties file created
+// by the audit setup. This ensures the HMAC secret key is not persisted to
+// disk after the vault is locked or the app closes.
+func (m model) deleteClientProperties() {
+	// Try to delete from the configured Docker compose location if available.
+	// DockerComposePath is a file path (e.g. .../docker/docker-compose.yml),
+	// so use its parent directory to locate the certs/ subdirectory.
+	if m.cfg.Audit.DockerComposePath != "" {
 		composeDir := filepath.Dir(m.cfg.Audit.DockerComposePath)
 		clientPropsPath := filepath.Join(composeDir, "certs", "client.properties")
 		if err := os.Remove(clientPropsPath); err != nil && !os.IsNotExist(err) {
-			_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not delete client.properties: %v\n", err)
+			_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not delete client.properties at %s: %v\n", clientPropsPath, err)
 		}
+		return
 	}
 
-	return m, tea.Quit
+	// Fallback: check the default ~/.tegata/docker/certs/client.properties location
+	// in case DockerComposePath is not set (e.g., shutdown before any unlock).
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	defaultPath := filepath.Join(homeDir, ".tegata", "docker", "certs", "client.properties")
+	if err := os.Remove(defaultPath); err != nil && !os.IsNotExist(err) {
+		_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not delete client.properties at %s: %v\n", defaultPath, err)
+	}
 }
 
 // isInputFocused returns true when a text input sub-model currently has focus,

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -545,6 +546,20 @@ func (m model) quit() (tea.Model, tea.Cmd) {
 	}
 	// Clear sensitive data from config
 	m.cfg.Audit.SecretKey = ""
+
+	// Stop Docker audit stack on exit (mirrors GUI shutdown behavior).
+	if m.cfg.Audit.DockerComposePath != "" {
+		if err := audit.StopStack(m.cfg.Audit.DockerComposePath); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Warning: could not stop audit server: %v\n", err)
+		}
+		// Delete the plaintext client.properties now that the stack is stopped.
+		composeDir := filepath.Dir(m.cfg.Audit.DockerComposePath)
+		clientPropsPath := filepath.Join(composeDir, "certs", "client.properties")
+		if err := os.Remove(clientPropsPath); err != nil && !os.IsNotExist(err) {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not delete client.properties: %v\n", err)
+		}
+	}
+
 	return m, tea.Quit
 }
 


### PR DESCRIPTION
## Summary

This PR stops the Docker audit stack when the TUI exits, matching the behavior of the GUI shutdown hook.

## Related issues or PRs

N/A

## Changes made

- Added `audit.StopStack()` call to the `quit()` function in `tui_model.go`
- Added cleanup of plaintext `client.properties` file after stopping the stack
- Added `path/filepath` import to support path operations

## Technical implementation

- **Approach:** Mirror the GUI's `shutdown()` hook behavior by stopping the Docker audit stack during TUI quit, ensuring containers are properly cleaned up on exit
- **Key components modified:** `cmd/tegata/tui_model.go` - `quit()` function
- **Dependencies added/removed:** Added `path/filepath` import (already in standard library)
- **Design patterns used:** Deferred cleanup pattern matching GUI shutdown lifecycle

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [x] Builds successfully on Windows (amd64)
- [ ] Builds successfully on Linux (amd64)
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] CLI commands tested manually with expected inputs
- [ ] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable)
- [x] ScalarDL integration tested (if applicable)
- [ ] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [x] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [x] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## Additional context

**Issue:** Stopping Docker containers works as expected when using the GUI, but not the TUI. The GUI's `shutdown()` hook calls `audit.StopStack()` automatically on app close, while the TUI's `quit()` function had no equivalent cleanup.

**Before:** TUI exits but Docker containers keep running.

**After:** TUI exits and Docker containers are stopped, with `client.properties` cleaned up, exactly as in the GUI.