### PR TITLE
Isolate Docker audit stack per vault

### DIFF
--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -349,7 +349,7 @@ func (a *App) deleteClientProperties() {
 	if err != nil {
 		return
 	}
-	matches, _ := filepath.Glob(filepath.Join(homeDir, ".tegata", "docker", "*", "certs", "client.properties"))
+	matches, _ := filepath.Glob(filepath.Join(homeDir, ".tegata", "docker", "*", "certs", "client.properties")) // Glob only errors on malformed patterns, not missing paths
 	for _, p := range matches {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not delete client.properties at %s: %v\n", p, err)

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -77,7 +77,7 @@ func (a *App) startup(ctx context.Context) {
 func (a *App) shutdown(_ context.Context) {
 	a.deleteClientProperties()
 	if a.config.Audit.DockerComposePath != "" {
-		_ = audit.StopStack(a.config.Audit.DockerComposePath)
+		_ = audit.StopStack(a.config.Audit.DockerComposePath, a.config.Audit.DockerProjectName)
 	}
 	a.LockVault()
 }
@@ -343,15 +343,17 @@ func (a *App) deleteClientProperties() {
 		return
 	}
 
-	// Fallback: check the default ~/.tegata/docker/certs/client.properties location
-	// in case DockerComposePath is not set (e.g., shutdown before any unlock).
+	// Fallback: scan all per-vault compose directories for client.properties.
+	// This handles shutdown before any vault was unlocked (DockerComposePath empty).
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return
 	}
-	defaultPath := filepath.Join(homeDir, ".tegata", "docker", "certs", "client.properties")
-	if err := os.Remove(defaultPath); err != nil && !os.IsNotExist(err) {
-		_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not delete client.properties at %s: %v\n", defaultPath, err)
+	matches, _ := filepath.Glob(filepath.Join(homeDir, ".tegata", "docker", "*", "certs", "client.properties"))
+	for _, p := range matches {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata-gui: warning: could not delete client.properties at %s: %v\n", p, err)
+		}
 	}
 }
 
@@ -1154,7 +1156,7 @@ func (a *App) RestartAuditServer() error {
 	if a.config.Audit.DockerComposePath == "" {
 		return fmt.Errorf("audit Docker setup not found. Run StartAuditServer first")
 	}
-	return audit.StartStack(a.config.Audit.DockerComposePath)
+	return audit.StartStack(a.config.Audit.DockerComposePath, a.config.Audit.DockerProjectName)
 }
 
 // StartAuditServer runs the full Docker audit setup sequence. It calls
@@ -1176,7 +1178,7 @@ func (a *App) StartAuditServer() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolving home directory: %w", err)
 	}
-	composeDir := filepath.Join(u.HomeDir, ".tegata", "docker")
+	composeDir := audit.ComposeDirForVault(u.HomeDir, vaultID)
 
 	// Strip the docker-bundle/ prefix from the embed.FS.
 	bundleFS, err := fs.Sub(dockerBundle, "docker-bundle")
@@ -1249,7 +1251,7 @@ func (a *App) StopAuditServer() error {
 		return fmt.Errorf("audit Docker setup not found. Run StartAuditServer first")
 	}
 
-	return audit.StopStack(a.config.Audit.DockerComposePath)
+	return audit.StopStack(a.config.Audit.DockerComposePath, a.config.Audit.DockerProjectName)
 }
 
 // IsAuditConfigured returns whether audit logging has been enabled by the user.

--- a/cmd/tegata/helpers.go
+++ b/cmd/tegata/helpers.go
@@ -314,6 +314,9 @@ func newEventBuilder(cfg config.Config, vaultDir string, passphrase []byte) (*au
 // (e.g. tegata add → vault-unlock + credential-add).
 func setupAuditBuilder(w io.Writer, dir string, passphrase []byte, mgr *vault.Manager) *audit.EventBuilder {
 	cfg, _ := config.Load(dir)
+	if secret := mgr.GetSecret("audit.secret_key"); secret != "" {
+		cfg.Audit.SecretKey = secret
+	}
 	builder, err := newEventBuilder(cfg, dir, passphrase)
 	if err != nil {
 		_, _ = fmt.Fprintf(w, "Warning: Audit unavailable: %v\n", err)

--- a/cmd/tegata/helpers.go
+++ b/cmd/tegata/helpers.go
@@ -317,6 +317,7 @@ func setupAuditBuilder(w io.Writer, dir string, passphrase []byte, mgr *vault.Ma
 	if secret := mgr.GetSecret("audit.secret_key"); secret != "" {
 		cfg.Audit.SecretKey = secret
 	}
+	defer func() { cfg.Audit.SecretKey = "" }()
 	builder, err := newEventBuilder(cfg, dir, passphrase)
 	if err != nil {
 		_, _ = fmt.Fprintf(w, "Warning: Audit unavailable: %v\n", err)

--- a/cmd/tegata/init.go
+++ b/cmd/tegata/init.go
@@ -116,7 +116,7 @@ func runInitAudit(vaultPath, dir string, passphrase []byte) {
 		fmt.Fprintf(os.Stderr, "Audit setup failed: %v\nRun 'tegata ledger start' to retry.\n", err)
 		return
 	}
-	composeDir := filepath.Join(u.HomeDir, ".tegata", "docker")
+	composeDir := audit.ComposeDirForVault(u.HomeDir, vaultID)
 
 	bundleFS, err := fs.Sub(dockerBundle, "docker-bundle")
 	if err != nil {

--- a/cmd/tegata/ledger.go
+++ b/cmd/tegata/ledger.go
@@ -241,12 +241,12 @@ func runLedgerStart(cmd *cobra.Command, _ []string) error {
 	vaultID := mgr.VaultID()
 	defer mgr.Close()
 
-	// Resolve compose directory: ~/.tegata/docker/
+	// Resolve per-vault compose directory: ~/.tegata/docker/<entityID>/
 	u, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("resolving home directory: %w", err)
 	}
-	composeDir := filepath.Join(u.HomeDir, ".tegata", "docker")
+	composeDir := audit.ComposeDirForVault(u.HomeDir, vaultID)
 
 	// Strip the docker-bundle/ prefix from the embed.FS so SetupStack
 	// receives an FS rooted at the docker-compose.yml level.
@@ -334,7 +334,7 @@ func runLedgerStop(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("audit Docker setup not found. Run 'tegata ledger start' first")
 	}
 
-	if err := audit.StopStack(cfg.Audit.DockerComposePath); err != nil {
+	if err := audit.StopStack(cfg.Audit.DockerComposePath, cfg.Audit.DockerProjectName); err != nil {
 		return err
 	}
 

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -584,7 +584,7 @@ func (m model) deleteClientProperties() {
 	if err != nil {
 		return
 	}
-	matches, _ := filepath.Glob(filepath.Join(homeDir, ".tegata", "docker", "*", "certs", "client.properties"))
+	matches, _ := filepath.Glob(filepath.Join(homeDir, ".tegata", "docker", "*", "certs", "client.properties")) // Glob only errors on malformed patterns, not missing paths
 	for _, p := range matches {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 			_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not delete client.properties at %s: %v\n", p, err)

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -552,7 +552,7 @@ func (m model) quit() (tea.Model, tea.Cmd) {
 
 	// Stop Docker audit stack on exit (mirrors GUI shutdown behavior).
 	if m.cfg.Audit.DockerComposePath != "" {
-		if err := audit.StopStack(m.cfg.Audit.DockerComposePath); err != nil {
+		if err := audit.StopStack(m.cfg.Audit.DockerComposePath, m.cfg.Audit.DockerProjectName); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Warning: could not stop audit server: %v\n", err)
 		}
 	}
@@ -578,15 +578,17 @@ func (m model) deleteClientProperties() {
 		return
 	}
 
-	// Fallback: check the default ~/.tegata/docker/certs/client.properties location
-	// in case DockerComposePath is not set (e.g., shutdown before any unlock).
+	// Fallback: scan all per-vault compose directories for client.properties.
+	// This handles shutdown before any vault was unlocked (DockerComposePath empty).
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return
 	}
-	defaultPath := filepath.Join(homeDir, ".tegata", "docker", "certs", "client.properties")
-	if err := os.Remove(defaultPath); err != nil && !os.IsNotExist(err) {
-		_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not delete client.properties at %s: %v\n", defaultPath, err)
+	matches, _ := filepath.Glob(filepath.Join(homeDir, ".tegata", "docker", "*", "certs", "client.properties"))
+	for _, p := range matches {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not delete client.properties at %s: %v\n", p, err)
+		}
 	}
 }
 

--- a/cmd/tegata/tui_overlay_audit.go
+++ b/cmd/tegata/tui_overlay_audit.go
@@ -451,7 +451,7 @@ func auditStartCmd(cfg config.Config, vaultPath, vaultID string) tea.Cmd {
 		if err != nil {
 			return auditStartMsg{err: fmt.Errorf("resolving home directory: %w", err)}
 		}
-		composeDir := filepath.Join(u.HomeDir, ".tegata", "docker")
+		composeDir := audit.ComposeDirForVault(u.HomeDir, vaultID)
 
 		bundleFS, err := fs.Sub(dockerBundle, "docker-bundle")
 		if err != nil {

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -210,7 +210,11 @@ func syncDockerCompose(fsys fs.FS, composePath, entityID string) error {
 		return fmt.Errorf("reading embedded docker-compose.yml: %w", err)
 	}
 	if entityID != "" {
-		data = rewriteComposeVolume(data, entityID)
+		rewritten, ok := rewriteComposeVolume(data, entityID)
+		if !ok {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: volume name %q not found in docker-compose.yml; per-vault isolation may not be applied\n", "tegata-scalardl-data")
+		}
+		data = rewritten
 	}
 	return os.WriteFile(composePath, data, 0600)
 }
@@ -240,7 +244,11 @@ func extractComposeFiles(fsys fs.FS, targetDir, entityID string) error {
 		}
 
 		if entityID != "" && path == "docker-compose.yml" {
-			data = rewriteComposeVolume(data, entityID)
+			rewritten, ok := rewriteComposeVolume(data, entityID)
+			if !ok {
+				_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: volume name %q not found in docker-compose.yml; per-vault isolation may not be applied\n", "tegata-scalardl-data")
+			}
+			data = rewritten
 		}
 
 		if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
@@ -290,13 +298,16 @@ func ComposeDirForVault(homeDir, vaultID string) string {
 }
 
 // rewriteComposeVolume replaces the global volume name in docker-compose.yml
-// content with a per-vault name. This ensures each vault's PostgreSQL data is
-// stored in an isolated Docker named volume. entityID must be non-empty.
-func rewriteComposeVolume(data []byte, entityID string) []byte {
-	return bytes.ReplaceAll(data,
-		[]byte("name: tegata-scalardl-data"),
-		[]byte("name: "+entityID+"-scalardl-data"),
-	)
+// content with a per-vault name. Returns the rewritten data and true if the
+// substitution was made, or the original data and false if the target string
+// was not found (compose file format may have drifted from expectations).
+// entityID must be non-empty.
+func rewriteComposeVolume(data []byte, entityID string) ([]byte, bool) {
+	target := []byte("name: tegata-scalardl-data")
+	if !bytes.Contains(data, target) {
+		return data, false
+	}
+	return bytes.ReplaceAll(data, target, []byte("name: "+entityID+"-scalardl-data")), true
 }
 
 // runDockerCompose executes a docker compose command with the given compose

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -201,18 +202,24 @@ func generateSecretKey() (string, error) {
 // composePath on disk, keeping the live file in sync with the embedded bundle.
 // Called by EnsureStack and MaybeAutoStart so that binary upgrades
 // automatically update the running compose configuration without requiring
-// the user to re-run `tegata ledger start`.
-func syncDockerCompose(fsys fs.FS, composePath string) error {
+// the user to re-run `tegata ledger start`. When entityID is non-empty the
+// global volume name is rewritten to a per-vault name before writing.
+func syncDockerCompose(fsys fs.FS, composePath, entityID string) error {
 	data, err := fs.ReadFile(fsys, "docker-compose.yml")
 	if err != nil {
 		return fmt.Errorf("reading embedded docker-compose.yml: %w", err)
+	}
+	if entityID != "" {
+		data = rewriteComposeVolume(data, entityID)
 	}
 	return os.WriteFile(composePath, data, 0600)
 }
 
 // extractComposeFiles walks the provided fs.FS and writes each file to
-// targetDir, preserving the directory structure.
-func extractComposeFiles(fsys fs.FS, targetDir string) error {
+// targetDir, preserving the directory structure. When entityID is non-empty,
+// docker-compose.yml is rewritten with a per-vault volume name so each vault's
+// PostgreSQL data is stored in an isolated Docker named volume.
+func extractComposeFiles(fsys fs.FS, targetDir, entityID string) error {
 	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -230,6 +237,10 @@ func extractComposeFiles(fsys fs.FS, targetDir string) error {
 		data, err := fs.ReadFile(fsys, path)
 		if err != nil {
 			return fmt.Errorf("reading embedded file %s: %w", path, err)
+		}
+
+		if entityID != "" && path == "docker-compose.yml" {
+			data = rewriteComposeVolume(data, entityID)
 		}
 
 		if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
@@ -271,10 +282,33 @@ scalar.dl.client.entity.identity.hmac.secret_key_version=1
 	return os.WriteFile(filepath.Join(certsDir, "bootstrap.properties"), []byte(props("scalardl-ledger")), 0600)
 }
 
+// ComposeDirForVault returns the per-vault Docker Compose directory path.
+// Directory is named after the vault's entity ID so the correspondence is
+// explicit: ~/.tegata/docker/tegata-<slug>/
+func ComposeDirForVault(homeDir, vaultID string) string {
+	return filepath.Join(homeDir, ".tegata", "docker", entityIDFromVaultID(vaultID))
+}
+
+// rewriteComposeVolume replaces the global volume name in docker-compose.yml
+// content with a per-vault name. This ensures each vault's PostgreSQL data is
+// stored in an isolated Docker named volume. entityID must be non-empty.
+func rewriteComposeVolume(data []byte, entityID string) []byte {
+	return bytes.ReplaceAll(data,
+		[]byte("name: tegata-scalardl-data"),
+		[]byte("name: "+entityID+"-scalardl-data"),
+	)
+}
+
 // runDockerCompose executes a docker compose command with the given compose
-// file path and arguments. Returns an error with stdout+stderr on failure.
-func runDockerCompose(composePath string, args ...string) error {
-	cmdArgs := append([]string{"compose", "-f", composePath}, args...)
+// file path, optional project name, and arguments. Returns an error with
+// stdout+stderr on failure. When projectName is non-empty, --project-name is
+// passed to override the name: directive in the compose file.
+func runDockerCompose(composePath, projectName string, args ...string) error {
+	cmdArgs := []string{"compose", "-f", composePath}
+	if projectName != "" {
+		cmdArgs = append(cmdArgs, "--project-name", projectName)
+	}
+	cmdArgs = append(cmdArgs, args...)
 	cmd := dockerCmd(cmdArgs...)
 
 	output, err := cmd.CombinedOutput()
@@ -326,17 +360,20 @@ func SetupStack(fsys fs.FS, composeDir, vaultID string, progressFn func(string),
 		return config.AuditConfig{}, err
 	}
 
-	// Step 2: Extract compose files.
+	// Step 3 (preliminary): Derive entity ID now so it can be used when
+	// extracting compose files with per-vault volume name rewriting.
+	entityID := entityIDFromVaultID(vaultID)
+
+	// Step 2: Extract compose files with per-vault volume name.
 	progress(progressFn, "Extracting compose files to "+composeDir+"...")
 	if err := os.MkdirAll(composeDir, 0700); err != nil {
 		return config.AuditConfig{}, fmt.Errorf("creating compose directory: %w", err)
 	}
-	if err := extractComposeFiles(fsys, composeDir); err != nil {
+	if err := extractComposeFiles(fsys, composeDir, entityID); err != nil {
 		return config.AuditConfig{}, fmt.Errorf("extracting compose files: %w", err)
 	}
 
-	// Step 3: Generate entity ID and secret key.
-	entityID := entityIDFromVaultID(vaultID)
+	// Step 3: Generate secret key (entity ID already derived above).
 	secretKey, err := generateSecretKey()
 	if err != nil {
 		return config.AuditConfig{}, err
@@ -355,11 +392,11 @@ func SetupStack(fsys fs.FS, composeDir, vaultID string, progressFn func(string),
 	// contracts registered via scalardl-hashstore bootstrap).
 	composePath := filepath.Join(composeDir, "docker-compose.yml")
 	progress(progressFn, "Starting Docker stack...")
-	if err := StartStack(composePath); err != nil {
+	if err := StartStack(composePath, entityID); err != nil {
 		return config.AuditConfig{}, fmt.Errorf("starting Docker stack: %w", err)
 	}
 	progress(progressFn, "Registering contracts for entity...")
-	if err := runDockerCompose(composePath, "up", "-d", "--force-recreate", "scalardl-contract-registration"); err != nil {
+	if err := runDockerCompose(composePath, entityID, "up", "-d", "--force-recreate", "scalardl-contract-registration"); err != nil {
 		return config.AuditConfig{}, fmt.Errorf("restarting contract registration: %w", err)
 	}
 
@@ -374,6 +411,7 @@ func SetupStack(fsys fs.FS, composeDir, vaultID string, progressFn func(string),
 		KeyVersion:        1,
 		Insecure:          true,
 		DockerComposePath: composePath,
+		DockerProjectName: entityID,
 	}
 
 	if err := waitForLedger(cfg); err != nil {
@@ -469,22 +507,25 @@ func waitForLedger(cfg config.AuditConfig) error {
 }
 
 // StartStack runs `docker compose -f composePath up -d` synchronously.
-// Returns an error with Docker stdout+stderr on non-zero exit.
-func StartStack(composePath string) error {
-	return runDockerCompose(composePath, "up", "-d")
+// projectName, when non-empty, is passed as --project-name to scope containers
+// and volumes to this vault's stack. Returns an error with Docker stdout+stderr
+// on non-zero exit.
+func StartStack(composePath, projectName string) error {
+	return runDockerCompose(composePath, projectName, "up", "-d")
 }
 
 // StopStack runs `docker compose -f composePath stop`, preserving the named
-// volume so audit history is retained.
-func StopStack(composePath string) error {
-	return runDockerCompose(composePath, "stop")
+// volume so audit history is retained. projectName scopes the command to the
+// correct stack when non-empty.
+func StopStack(composePath, projectName string) error {
+	return runDockerCompose(composePath, projectName, "stop")
 }
 
 // TeardownStack runs `docker compose -f composePath down -v`, removing
 // containers and the named volume. Use this only in integration tests for
 // post-test cleanup — it permanently deletes all audit history.
-func TeardownStack(composePath string) error {
-	return runDockerCompose(composePath, "down", "-v")
+func TeardownStack(composePath, projectName string) error {
+	return runDockerCompose(composePath, projectName, "down", "-v")
 }
 
 // EnsureStack starts the Docker audit stack synchronously, suitable for
@@ -510,7 +551,7 @@ func EnsureStack(cfg config.AuditConfig, fsys fs.FS, progressFn func(string)) er
 	// Sync docker-compose.yml from the embedded bundle so binary upgrades
 	// (e.g. ScalarDL version bumps) take effect automatically.
 	if fsys != nil {
-		if err := syncDockerCompose(fsys, cfg.DockerComposePath); err != nil {
+		if err := syncDockerCompose(fsys, cfg.DockerComposePath, cfg.DockerProjectName); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not sync docker-compose.yml: %v\n", err)
 		}
 	}
@@ -531,7 +572,7 @@ func EnsureStack(cfg config.AuditConfig, fsys fs.FS, progressFn func(string)) er
 	if err := ensureDockerDaemon(); err != nil {
 		return fmt.Errorf("docker daemon not ready: %w", err)
 	}
-	if err := StartStack(cfg.DockerComposePath); err != nil {
+	if err := StartStack(cfg.DockerComposePath, cfg.DockerProjectName); err != nil {
 		return fmt.Errorf("starting audit stack: %w", err)
 	}
 	_, _ = fmt.Fprintln(os.Stderr, "tegata: waiting for ledger to become ready...")
@@ -540,6 +581,7 @@ func EnsureStack(cfg config.AuditConfig, fsys fs.FS, progressFn func(string)) er
 		return fmt.Errorf("ledger did not become ready: %w", err)
 	}
 	progress(progressFn, "Audit server ready.")
+	_, _ = fmt.Fprintln(os.Stderr, "tegata: ledger stack started. Run 'tegata ledger stop' to shut it down when finished.")
 	return nil
 }
 
@@ -557,7 +599,7 @@ func MaybeAutoStart(cfg config.AuditConfig, fsys fs.FS) {
 	}
 	go func() {
 		if fsys != nil {
-			if err := syncDockerCompose(fsys, cfg.DockerComposePath); err != nil {
+			if err := syncDockerCompose(fsys, cfg.DockerComposePath, cfg.DockerProjectName); err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not sync docker-compose.yml: %v\n", err)
 			}
 		}
@@ -565,7 +607,7 @@ func MaybeAutoStart(cfg config.AuditConfig, fsys fs.FS) {
 			_, _ = fmt.Fprintf(os.Stderr, "tegata: audit auto-start: Docker daemon not ready: %v\n", err)
 			return
 		}
-		if err := StartStack(cfg.DockerComposePath); err != nil {
+		if err := StartStack(cfg.DockerComposePath, cfg.DockerProjectName); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "tegata: audit auto-start failed: %v\n", err)
 			return
 		}

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -360,11 +360,8 @@ func SetupStack(fsys fs.FS, composeDir, vaultID string, progressFn func(string),
 		return config.AuditConfig{}, err
 	}
 
-	// Step 3 (preliminary): Derive entity ID now so it can be used when
-	// extracting compose files with per-vault volume name rewriting.
+	// Step 2: Derive entity ID and extract compose files with per-vault volume name.
 	entityID := entityIDFromVaultID(vaultID)
-
-	// Step 2: Extract compose files with per-vault volume name.
 	progress(progressFn, "Extracting compose files to "+composeDir+"...")
 	if err := os.MkdirAll(composeDir, 0700); err != nil {
 		return config.AuditConfig{}, fmt.Errorf("creating compose directory: %w", err)
@@ -373,7 +370,7 @@ func SetupStack(fsys fs.FS, composeDir, vaultID string, progressFn func(string),
 		return config.AuditConfig{}, fmt.Errorf("extracting compose files: %w", err)
 	}
 
-	// Step 3: Generate secret key (entity ID already derived above).
+	// Step 3: Generate secret key.
 	secretKey, err := generateSecretKey()
 	if err != nil {
 		return config.AuditConfig{}, err

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -91,7 +91,7 @@ func TestIntegration_SetupStack_HappyPath(t *testing.T) {
 	// Register cleanup: tear down the stack (removes containers and volume).
 	composePath := filepath.Join(composeWorkDir, "docker-compose.yml")
 	t.Cleanup(func() {
-		_ = audit.TeardownStack(composePath)
+		_ = audit.TeardownStack(composePath, cfg.DockerProjectName)
 	})
 
 	// Verify returned AuditConfig has expected values.
@@ -106,6 +106,9 @@ func TestIntegration_SetupStack_HappyPath(t *testing.T) {
 	}
 	if cfg.EntityID == "" || len(cfg.EntityID) < 7 {
 		t.Errorf("cfg.EntityID = %q, want non-empty starting with tegata-", cfg.EntityID)
+	}
+	if cfg.DockerProjectName != cfg.EntityID {
+		t.Errorf("cfg.DockerProjectName = %q, want %q (same as EntityID)", cfg.DockerProjectName, cfg.EntityID)
 	}
 	if !cfg.Enabled {
 		t.Error("cfg.Enabled = false, want true")
@@ -156,10 +159,10 @@ func TestIntegration_MaybeAutoStart(t *testing.T) {
 	}
 
 	composePath := filepath.Join(composeWorkDir, "docker-compose.yml")
-	t.Cleanup(func() { _ = audit.TeardownStack(composePath) })
+	t.Cleanup(func() { _ = audit.TeardownStack(composePath, cfg.DockerProjectName) })
 
 	// Stop without removing the volume to simulate "stack exists but is stopped".
-	if err := audit.StopStack(composePath); err != nil {
+	if err := audit.StopStack(composePath, cfg.DockerProjectName); err != nil {
 		t.Fatalf("stopping Docker stack: %v", err)
 	}
 	t.Log("Docker stack stopped")
@@ -237,7 +240,7 @@ func TestIntegration_StopStack_NonExistentCompose(t *testing.T) {
 	requireDocker(t)
 
 	// Attempt to stop a compose stack at a non-existent path.
-	err := audit.StopStack("/nonexistent/path/docker-compose.yml")
+	err := audit.StopStack("/nonexistent/path/docker-compose.yml", "")
 	if err == nil {
 		t.Fatal("StopStack: expected error for non-existent path, got nil")
 	}
@@ -279,7 +282,7 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 		t.Fatalf("SetupStack: %v", err)
 	}
 	composePath := filepath.Join(composeWorkDir, "docker-compose.yml")
-	t.Cleanup(func() { _ = audit.TeardownStack(composePath) })
+	t.Cleanup(func() { _ = audit.TeardownStack(composePath, cfg.DockerProjectName) })
 
 	client, err := audit.NewClientFromConfig(cfg)
 	if err != nil {

--- a/internal/audit/docker_integration_test.go
+++ b/internal/audit/docker_integration_test.go
@@ -291,10 +291,9 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	defer func() { _ = client.Close() }()
 
 	// runSQL executes a SQL statement directly in the ScalarDL PostgreSQL
-	// container via docker exec. The container name is always
-	// tegata-ledger-postgres-1 because the compose project name is fixed to
-	// "tegata-ledger" in docker-compose.yml (see the `name:` field at the top
-	// of that file). If the compose project name changes, update this string.
+	// container via docker exec. The container name is derived from the compose
+	// project name (<projectName>-postgres-1) so it stays correct regardless of
+	// which vault slug was used during SetupStack.
 	//
 	// All callers issue UPDATE statements targeting a single row. runSQL asserts
 	// that psql reports "UPDATE 1" so that a silent zero-row update (e.g. due to
@@ -302,10 +301,11 @@ func TestIntegration_TamperingDetection(t *testing.T) {
 	// than letting assertTampering fail with a confusing Valid=true. The id value
 	// interpolated into each SQL string is always a UUID from evt.EventID (hex
 	// digits and hyphens only), so fmt.Sprintf is safe here.
+	postgresContainer := cfg.DockerProjectName + "-postgres-1"
 	runSQL := func(t *testing.T, sql string) {
 		t.Helper()
 		out, err := exec.Command(
-			"docker", "exec", "tegata-ledger-postgres-1",
+			"docker", "exec", postgresContainer,
 			"psql", "-U", "scalardl", "-d", "scalardl", "-c", sql,
 		).CombinedOutput()
 		if err != nil {

--- a/internal/audit/docker_test.go
+++ b/internal/audit/docker_test.go
@@ -59,7 +59,7 @@ func TestExtractComposeFiles(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	if err := extractComposeFiles(fsys, dir); err != nil {
+	if err := extractComposeFiles(fsys, dir, ""); err != nil {
 		t.Fatalf("extractComposeFiles: %v", err)
 	}
 

--- a/internal/audit/docker_test.go
+++ b/internal/audit/docker_test.go
@@ -1,7 +1,9 @@
 package audit
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -91,6 +93,94 @@ func TestDetectDocker_NotFound(t *testing.T) {
 	if !strings.Contains(err.Error(), "docker binary not found") {
 		t.Errorf("detectDocker error = %q, want to contain 'docker binary not found'", err.Error())
 	}
+}
+
+// TestComposeDirForVault verifies the per-vault compose directory path format.
+func TestComposeDirForVault(t *testing.T) {
+	got := ComposeDirForVault("/home/user", "a3f2c810-1234-4567-89ab-cdef01234567")
+	want := filepath.Join("/home/user", ".tegata", "docker", "tegata-a3f2c810")
+	if got != want {
+		t.Errorf("ComposeDirForVault = %q, want %q", got, want)
+	}
+}
+
+// TestRewriteComposeVolume verifies the volume name substitution logic.
+func TestRewriteComposeVolume(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		entityID string
+		want     string
+	}{
+		{
+			name:     "rewrites matching volume name",
+			input:    "volumes:\n  scalardl-data:\n    name: tegata-scalardl-data\n",
+			entityID: "tegata-abc12345",
+			want:     "volumes:\n  scalardl-data:\n    name: tegata-abc12345-scalardl-data\n",
+		},
+		{
+			name:     "no match leaves data unchanged",
+			input:    "volumes:\n  other:\n    name: something-else\n",
+			entityID: "tegata-abc12345",
+			want:     "volumes:\n  other:\n    name: something-else\n",
+		},
+		{
+			name:     "replaces all occurrences",
+			input:    "name: tegata-scalardl-data\nname: tegata-scalardl-data\n",
+			entityID: "tegata-def67890",
+			want:     "name: tegata-def67890-scalardl-data\nname: tegata-def67890-scalardl-data\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rewriteComposeVolume([]byte(tc.input), tc.entityID)
+			if string(got) != tc.want {
+				t.Errorf("rewriteComposeVolume = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSyncDockerCompose_RewritesVolume verifies that syncDockerCompose rewrites
+// the volume name when entityID is non-empty and leaves it unchanged when empty.
+func TestSyncDockerCompose_RewritesVolume(t *testing.T) {
+	const composeContent = "volumes:\n  scalardl-data:\n    name: tegata-scalardl-data\n"
+	fsys := fstest.MapFS{
+		"docker-compose.yml": &fstest.MapFile{Data: []byte(composeContent)},
+	}
+
+	t.Run("rewrites volume with entityID", func(t *testing.T) {
+		dir := t.TempDir()
+		composePath := filepath.Join(dir, "docker-compose.yml")
+		if err := syncDockerCompose(fsys, composePath, "tegata-abc12345"); err != nil {
+			t.Fatalf("syncDockerCompose: %v", err)
+		}
+		got, err := os.ReadFile(composePath)
+		if err != nil {
+			t.Fatalf("reading file: %v", err)
+		}
+		if !bytes.Contains(got, []byte("name: tegata-abc12345-scalardl-data")) {
+			t.Errorf("rewritten volume name not found in output: %s", got)
+		}
+		if bytes.Contains(got, []byte("name: tegata-scalardl-data\n")) {
+			t.Errorf("original volume name still present in output: %s", got)
+		}
+	})
+
+	t.Run("leaves volume unchanged when entityID empty", func(t *testing.T) {
+		dir := t.TempDir()
+		composePath := filepath.Join(dir, "docker-compose.yml")
+		if err := syncDockerCompose(fsys, composePath, ""); err != nil {
+			t.Fatalf("syncDockerCompose: %v", err)
+		}
+		got, err := os.ReadFile(composePath)
+		if err != nil {
+			t.Fatalf("reading file: %v", err)
+		}
+		if !bytes.Contains(got, []byte("name: tegata-scalardl-data")) {
+			t.Errorf("expected original volume name in output: %s", got)
+		}
+	})
 }
 
 // TestMaybeAutoStart_NoPath verifies that auto-start is a no-op when

--- a/internal/audit/docker_test.go
+++ b/internal/audit/docker_test.go
@@ -73,6 +73,32 @@ func TestExtractComposeFiles(t *testing.T) {
 	}
 }
 
+// TestExtractComposeFiles_RewritesVolume verifies that extractComposeFiles
+// rewrites the Docker volume name in docker-compose.yml when entityID is set.
+func TestExtractComposeFiles_RewritesVolume(t *testing.T) {
+	const composeContent = "volumes:\n  scalardl-data:\n    name: tegata-scalardl-data\n"
+	fsys := fstest.MapFS{
+		"docker-compose.yml":      &fstest.MapFile{Data: []byte(composeContent)},
+		"certs/client.properties": &fstest.MapFile{Data: []byte("entity.id=test")},
+	}
+
+	dir := t.TempDir()
+	if err := extractComposeFiles(fsys, dir, "tegata-abc12345"); err != nil {
+		t.Fatalf("extractComposeFiles: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "docker-compose.yml"))
+	if err != nil {
+		t.Fatalf("reading docker-compose.yml: %v", err)
+	}
+	if !bytes.Contains(got, []byte("name: tegata-abc12345-scalardl-data")) {
+		t.Errorf("per-vault volume name not found in extracted compose file: %s", got)
+	}
+	if bytes.Contains(got, []byte("name: tegata-scalardl-data\n")) {
+		t.Errorf("original volume name still present in extracted compose file: %s", got)
+	}
+}
+
 // TestDetectDocker_NotFound verifies the error message when Docker is absent.
 // This test temporarily modifies PATH to simulate Docker being absent.
 // It skips when Docker is found at a known fallback location (e.g. during
@@ -107,35 +133,42 @@ func TestComposeDirForVault(t *testing.T) {
 // TestRewriteComposeVolume verifies the volume name substitution logic.
 func TestRewriteComposeVolume(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		entityID string
-		want     string
+		name      string
+		input     string
+		entityID  string
+		want      string
+		wantMatch bool
 	}{
 		{
-			name:     "rewrites matching volume name",
-			input:    "volumes:\n  scalardl-data:\n    name: tegata-scalardl-data\n",
-			entityID: "tegata-abc12345",
-			want:     "volumes:\n  scalardl-data:\n    name: tegata-abc12345-scalardl-data\n",
+			name:      "rewrites matching volume name",
+			input:     "volumes:\n  scalardl-data:\n    name: tegata-scalardl-data\n",
+			entityID:  "tegata-abc12345",
+			want:      "volumes:\n  scalardl-data:\n    name: tegata-abc12345-scalardl-data\n",
+			wantMatch: true,
 		},
 		{
-			name:     "no match leaves data unchanged",
-			input:    "volumes:\n  other:\n    name: something-else\n",
-			entityID: "tegata-abc12345",
-			want:     "volumes:\n  other:\n    name: something-else\n",
+			name:      "no match leaves data unchanged",
+			input:     "volumes:\n  other:\n    name: something-else\n",
+			entityID:  "tegata-abc12345",
+			want:      "volumes:\n  other:\n    name: something-else\n",
+			wantMatch: false,
 		},
 		{
-			name:     "replaces all occurrences",
-			input:    "name: tegata-scalardl-data\nname: tegata-scalardl-data\n",
-			entityID: "tegata-def67890",
-			want:     "name: tegata-def67890-scalardl-data\nname: tegata-def67890-scalardl-data\n",
+			name:      "replaces all occurrences",
+			input:     "name: tegata-scalardl-data\nname: tegata-scalardl-data\n",
+			entityID:  "tegata-def67890",
+			want:      "name: tegata-def67890-scalardl-data\nname: tegata-def67890-scalardl-data\n",
+			wantMatch: true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := rewriteComposeVolume([]byte(tc.input), tc.entityID)
+			got, ok := rewriteComposeVolume([]byte(tc.input), tc.entityID)
 			if string(got) != tc.want {
-				t.Errorf("rewriteComposeVolume = %q, want %q", got, tc.want)
+				t.Errorf("rewriteComposeVolume data = %q, want %q", got, tc.want)
+			}
+			if ok != tc.wantMatch {
+				t.Errorf("rewriteComposeVolume ok = %v, want %v", ok, tc.wantMatch)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,10 @@ type AuditConfig struct {
 	// one-click audit setup. When set, auto-start behavior is enabled on
 	// vault unlock (D-06, D-09).
 	DockerComposePath string
+	// DockerProjectName is the Docker Compose project name for the per-vault
+	// stack (e.g. "tegata-abc12345"). Used with --project-name to isolate
+	// containers and volumes per vault. Empty for legacy single-directory setups.
+	DockerProjectName string
 	// AutoStart controls whether MaybeAutoStart fires on vault unlock.
 	// Defaults to true when DockerComposePath is set and auto_start is absent
 	// from config (D-06 backwards compatibility). Defaults to false otherwise.
@@ -74,6 +78,7 @@ type tomlAuditConfig struct {
 	QueueMaxEvents    *int    `toml:"queue_max_events"`
 	Insecure          *bool   `toml:"insecure"`
 	DockerComposePath *string `toml:"docker_compose_path"`
+	DockerProjectName *string `toml:"docker_project_name"`
 	AutoStart         *bool   `toml:"auto_start"`
 }
 
@@ -175,6 +180,9 @@ func Load(dir string) (Config, error) {
 	}
 	if a.DockerComposePath != nil {
 		cfg.Audit.DockerComposePath = *a.DockerComposePath
+	}
+	if a.DockerProjectName != nil {
+		cfg.Audit.DockerProjectName = *a.DockerProjectName
 	}
 	if a.AutoStart != nil {
 		cfg.Audit.AutoStart = *a.AutoStart

--- a/internal/config/write_audit.go
+++ b/internal/config/write_audit.go
@@ -48,6 +48,9 @@ func formatAuditSection(cfg AuditConfig) string {
 	if cfg.DockerComposePath != "" {
 		buf.WriteString(fmt.Sprintf("docker_compose_path = %q\n", cfg.DockerComposePath))
 	}
+	if cfg.DockerProjectName != "" {
+		buf.WriteString(fmt.Sprintf("docker_project_name = %q\n", cfg.DockerProjectName))
+	}
 	buf.WriteString(fmt.Sprintf("auto_start = %t\n", cfg.AutoStart))
 	return buf.String()
 }

--- a/internal/config/write_audit_test.go
+++ b/internal/config/write_audit_test.go
@@ -141,6 +141,25 @@ func TestDockerComposePath_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestDockerProjectName_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := AuditConfig{
+		Enabled:           true,
+		DockerComposePath: "/home/user/.tegata/docker/tegata-abc12345/docker-compose.yml",
+		DockerProjectName: "tegata-abc12345",
+		AutoStart:         true,
+	}
+	_ = WriteAuditSection(dir, cfg)
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Audit.DockerProjectName != cfg.DockerProjectName {
+		t.Errorf("DockerProjectName round-trip: got %q, want %q",
+			loaded.Audit.DockerProjectName, cfg.DockerProjectName)
+	}
+}
+
 func TestWriteAuditSection_AutoStartTrue(t *testing.T) {
 	cfg := AuditConfig{AutoStart: true}
 	out := formatAuditSection(cfg)


### PR DESCRIPTION
## Summary

This PR implements per-vault Docker Compose isolation so each vault gets its own containers, project name, and PostgreSQL volume — preventing multiple vaults from sharing audit infrastructure. It also fixes a bug found during UAT where CLI commands silently queued all audit events instead of submitting them.

## Related issues or PRs

- Resolves #88

## Changes made

- Add `ComposeDirForVault()` to derive a per-vault compose directory (`~/.tegata/docker/tegata-<slug>/`) from the vault ID
- Add `rewriteComposeVolume()` to rename the Docker volume in `docker-compose.yml` to `tegata-<slug>-scalardl-data` at extraction time
- Pass `--project-name tegata-<slug>` to all `docker compose` invocations to scope containers and volumes per vault
- Add `DockerProjectName` field to `AuditConfig` with TOML round-trip support (`docker_project_name`)
- Update CLI (`ledger start/stop`, `init`), TUI overlay, TUI model, and GUI to use per-vault compose paths
- Fix `setupAuditBuilder()` to inject `audit.secret_key` from the vault's encrypted Secrets map before building the audit client (it was always empty, causing all CLI audit events to be silently queued)
- Add a hint message when `EnsureStack` auto-starts the ledger from a CLI command so users know to run `tegata ledger stop` when finished
- Update integration tests and unit tests for new function signatures

## Technical implementation

- **Approach:** Each vault's entity ID (`tegata-<first8hex>`) doubles as the Docker Compose project name and subdirectory name, making the vault-to-stack mapping explicit and human-readable.
- **Key components modified:** `internal/audit/docker.go`, `internal/config/config.go`, `internal/config/write_audit.go`, `cmd/tegata/ledger.go`, `cmd/tegata/helpers.go`, `cmd/tegata/init.go`, `cmd/tegata/tui_model.go`, `cmd/tegata/tui_overlay_audit.go`, `cmd/tegata-gui/app.go`
- **Dependencies added/removed:** None
- **Design patterns used:** Volume name is rewritten at compose file extraction time (not at runtime), keeping `docker compose` invocations simple. `DockerProjectName` is persisted in `tegata.toml` so stop/restart commands use the correct project name without re-deriving it.

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [x] Builds successfully on Windows (amd64)
- [ ] Builds successfully on Linux (amd64)
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] CLI commands tested manually with expected inputs
- [x] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable)
- [x] ScalarDL integration tested (if applicable)
- [ ] Cross-platform compatibility verified (if applicable)

**Manual UAT:** Sections A1 and A2 of `UAT-88-per-vault-audit-isolation.md` verified on macOS. Two vaults create separate `~/.tegata/docker/tegata-<slug>/` directories and separate named volumes. `ledger stop` cleans up `client.properties`. CLI auto-start fires correctly and hint message appears.

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable)

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [ ] No breaking changes
- [x] Breaking changes (describe below):

`StartStack`, `StopStack`, `TeardownStack`, and `runDockerCompose` signatures now require a `projectName string` parameter. Callers outside this repo using these as library functions would need to update. All internal callers have been updated.

Existing vaults with an empty `DockerProjectName` continue to work — the `--project-name` flag is omitted, preserving the old shared-stack behavior.

## Additional context

A manual UAT checklist covering CLI, TUI, and GUI surfaces is available at `UAT-88-per-vault-audit-isolation.md` in the repo root. Sections B (TUI) and C (GUI) remain to be verified before closing #88.

Port conflicts between vault stacks (ports 5432/50051/50052) are a known limitation documented in the UAT checklist and the original issue — only one vault's audit stack can run at a time.