### PR TITLE
Detect port conflicts and prevent silent wrong-ledger queries for audit stack

### DIFF
--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -1033,6 +1033,9 @@ func (a *App) GetAuditHistory() ([]AuditHistoryRecord, error) {
 		return nil, fmt.Errorf("vault is locked")
 	}
 
+	if err := audit.CheckLedgerAvailability(a.config.Audit); err != nil {
+		return nil, err
+	}
 	client, err := a.newAuditClient()
 	if err != nil {
 		return nil, err
@@ -1082,6 +1085,9 @@ func (a *App) VerifyCredentialAuditLog(label string) (*AuditVerifyResult, error)
 		return nil, fmt.Errorf("vault is locked")
 	}
 
+	if err := audit.CheckLedgerAvailability(a.config.Audit); err != nil {
+		return nil, err
+	}
 	client, err := a.newAuditClient()
 	if err != nil {
 		return nil, err
@@ -1115,6 +1121,9 @@ func (a *App) VerifyAuditLog() (*AuditVerifyResult, error) {
 		return nil, fmt.Errorf("vault is locked")
 	}
 
+	if err := audit.CheckLedgerAvailability(a.config.Audit); err != nil {
+		return nil, err
+	}
 	client, err := a.newAuditClient()
 	if err != nil {
 		return nil, err

--- a/cmd/tegata/history.go
+++ b/cmd/tegata/history.go
@@ -97,6 +97,9 @@ Requires audit to be enabled in tegata.toml ([audit] enabled = true).`,
 			labelMap := audit.BuildLabelMap(labels)
 			deletedMap := mgr.DeletedLabels()
 
+			if err := audit.CheckLedgerAvailability(cfg.Audit); err != nil {
+				return err
+			}
 			client, err := audit.NewClientFromConfig(cfg.Audit)
 			if err != nil {
 				return fmt.Errorf("%w: %s", tegerrors.ErrNetworkFailed, err)

--- a/cmd/tegata/tui_model.go
+++ b/cmd/tegata/tui_model.go
@@ -421,6 +421,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case unlockResultMsg:
 		return m.handleUnlockResult(msg)
 
+	case auditAutoStartMsg:
+		if msg.err != nil {
+			m.statusMsg = "Audit auto-start failed: " + msg.err.Error()
+		}
+		return m, nil
+
 	case auditHistoryMsg:
 		m.auditLoading = false
 		if msg.err != nil {

--- a/cmd/tegata/tui_overlay_audit.go
+++ b/cmd/tegata/tui_overlay_audit.go
@@ -44,6 +44,9 @@ type auditStartMsg struct {
 // auditHistoryCmd creates a tea.Cmd that fetches audit history asynchronously.
 func auditHistoryCmd(cfg config.AuditConfig) tea.Cmd {
 	return func() tea.Msg {
+		if err := audit.CheckLedgerAvailability(cfg); err != nil {
+			return auditHistoryMsg{err: err}
+		}
 		client, err := audit.NewClientFromConfig(cfg)
 		if err != nil {
 			return auditHistoryMsg{err: err}
@@ -79,6 +82,9 @@ func auditVerifyCmd(cfg config.AuditConfig, vaultHashes map[string]string) tea.C
 	return func() tea.Msg {
 		defer vault.ZeroAuditHashes(vaultHashes)
 
+		if err := audit.CheckLedgerAvailability(cfg); err != nil {
+			return auditVerifyMsg{err: err}
+		}
 		client, err := audit.NewClientFromConfig(cfg)
 		if err != nil {
 			return auditVerifyMsg{err: err}

--- a/cmd/tegata/tui_unlock.go
+++ b/cmd/tegata/tui_unlock.go
@@ -15,14 +15,33 @@ import (
 	"github.com/josh-wong/tegata/internal/vault"
 )
 
+// auditAutoStartMsg is returned by maybeAutoStartCmd when the background
+// auto-start attempt finishes. err is nil when the stack started successfully
+// or when auto-start is not configured; non-nil on failure.
+type auditAutoStartMsg struct{ err error }
+
+// maybeAutoStartCmd runs the Docker audit stack auto-start as a tea.Cmd so
+// errors route through the TUI message loop instead of being written directly
+// to stderr, which would corrupt the alt-screen renderer while the TUI is active.
+func maybeAutoStartCmd(cfg config.AuditConfig) tea.Cmd {
+	return func() tea.Msg {
+		bundleFS, _ := fs.Sub(dockerBundle, "docker-bundle")
+		err := audit.RunAutoStart(cfg, bundleFS)
+		return auditAutoStartMsg{err: err}
+	}
+}
+
 // unlockResultMsg is returned by unlockVaultCmd when the async vault unlock
 // goroutine completes. On success, mgr is non-nil. On failure, err is set.
 // The builder field carries the EventBuilder constructed while the passphrase
 // was still available; it may be nil when audit is disabled or unavailable.
+// auditCfg is populated when auto-start is configured so handleUnlockResult
+// can kick off maybeAutoStartCmd without re-reading the passphrase.
 type unlockResultMsg struct {
-	mgr     *vault.Manager
-	err     error
-	builder *audit.EventBuilder
+	mgr      *vault.Manager
+	err      error
+	builder  *audit.EventBuilder
+	auditCfg config.AuditConfig
 }
 
 // unlockVaultCmd spawns an async tea.Cmd that opens and unlocks the vault.
@@ -75,14 +94,10 @@ func unlockVaultCmd(path string, passphrase []byte) tea.Cmd {
 			cfg.Audit.SecretKey = secretFromVault
 		}
 
-		// Auto-start Docker audit stack if configured (D-09, D-10).
-		// MaybeAutoStart is a no-op when DockerComposePath is empty (D-11).
-		// Runs asynchronously — vault unlock is never blocked (D-10).
-		// On failure, MaybeAutoStart logs to stderr and queues events (D-13).
-		// Passes bundleFS so docker-compose.yml is synced on each run, keeping
-		// the live stack config current after binary upgrades.
-		bundleFS, _ := fs.Sub(dockerBundle, "docker-bundle")
-		audit.MaybeAutoStart(cfg.Audit, bundleFS)
+		// Auto-start is deferred to a tea.Cmd (maybeAutoStartCmd) issued by
+		// handleUnlockResult so any error routes through the TUI message loop
+		// instead of being written to stderr, which corrupts the alt-screen
+		// renderer. auditCfg is carried in the result for that purpose.
 
 		builder, builderErr := newEventBuilder(cfg, filepath.Dir(path), passphrase)
 		if builderErr != nil {
@@ -91,7 +106,7 @@ func unlockVaultCmd(path string, passphrase []byte) tea.Cmd {
 		}
 
 		zeroBytes(passphrase)
-		return unlockResultMsg{mgr: mgr, builder: builder}
+		return unlockResultMsg{mgr: mgr, builder: builder, auditCfg: cfg.Audit}
 	}
 }
 
@@ -153,7 +168,7 @@ func (m model) handleUnlockResult(msg unlockResultMsg) (tea.Model, tea.Cmd) {
 	m.prevState = stateMainView
 	m.errMsg = ""
 	m.lastActivity = time.Now()
-	return m, tickCmd()
+	return m, tea.Batch(tickCmd(), maybeAutoStartCmd(msg.auditCfg))
 }
 
 // updateUnlock handles key events in stateUnlock and stateLockedIdle.

--- a/cmd/tegata/verify.go
+++ b/cmd/tegata/verify.go
@@ -84,6 +84,9 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	hashes := mgr.AuditHashes()
 	defer vault.ZeroAuditHashes(hashes)
 
+	if err := audit.CheckLedgerAvailability(cfg.Audit); err != nil {
+		return err
+	}
 	client, err := audit.NewClientFromConfig(cfg.Audit)
 	if err != nil {
 		return fmt.Errorf("%w: connecting to ledger: %s", tegerrors.ErrNetworkFailed, err)

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -75,7 +75,10 @@ func checkPortsAvailable() error {
 // inject arbitrary ports without touching system-reserved port numbers.
 func checkPorts(ports []int) error {
 	for _, port := range ports {
-		addr := fmt.Sprintf("localhost:%d", port)
+		// Use 127.0.0.1 explicitly — on macOS, "localhost" may resolve to ::1
+		// (IPv6) while Docker Desktop binds ports to 127.0.0.1 (IPv4) only,
+		// causing a false "port free" result on a live container.
+		addr := fmt.Sprintf("127.0.0.1:%d", port)
 		conn, err := net.DialTimeout("tcp", addr, time.Second)
 		if err == nil {
 			_ = conn.Close()

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -82,7 +82,7 @@ func checkPorts(ports []int) error {
 		conn, err := net.DialTimeout("tcp", addr, time.Second)
 		if err == nil {
 			_ = conn.Close()
-			return fmt.Errorf("port %d is already in use. Stop the current vault's audit stack with \"tegata ledger stop\" before starting another.", port)
+			return fmt.Errorf("Port %d is already in use. Stop the current vault's audit stack with \"tegata ledger stop\" before starting another.", port)
 		}
 	}
 	return nil
@@ -123,7 +123,7 @@ func CheckLedgerAvailability(cfg config.AuditConfig) error {
 	if portErr := checkPortsAvailable(); portErr != nil {
 		return portErr
 	}
-	return fmt.Errorf("audit stack is not running. Start it with \"tegata ledger start\".")
+	return fmt.Errorf("Audit stack is not running. Start it with \"tegata ledger start\".")
 }
 
 // DockerBinPath returns the absolute path to the docker binary. It first

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,6 +57,32 @@ var knownDockerPaths = []string{
 	"/usr/bin/docker",
 	"/Applications/Docker.app/Contents/Resources/bin/docker",
 	"/opt/homebrew/bin/docker",
+}
+
+// auditPorts lists the TCP ports required by the Docker audit stack.
+// Checked before starting to detect conflicts with another vault's running stack.
+var auditPorts = []int{5432, 50051, 50052}
+
+// checkPortsAvailable returns an error if any of the required audit ports are
+// already bound. A port conflict means another vault's audit stack is already
+// running; the error message tells the user how to resolve it.
+func checkPortsAvailable() error {
+	return checkPorts(auditPorts)
+}
+
+// checkPorts dials each port in the list and returns an error on the first one
+// that is already bound. Separated from checkPortsAvailable to allow tests to
+// inject arbitrary ports without touching system-reserved port numbers.
+func checkPorts(ports []int) error {
+	for _, port := range ports {
+		addr := fmt.Sprintf("localhost:%d", port)
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return fmt.Errorf("port %d is already in use. Stop the current vault's audit stack with 'tegata ledger stop' before starting another", port)
+		}
+	}
+	return nil
 }
 
 // DockerBinPath returns the absolute path to the docker binary. It first
@@ -516,9 +543,12 @@ func waitForLedger(cfg config.AuditConfig) error {
 
 // StartStack runs `docker compose -f composePath up -d` synchronously.
 // projectName, when non-empty, is passed as --project-name to scope containers
-// and volumes to this vault's stack. Returns an error with Docker stdout+stderr
-// on non-zero exit.
+// and volumes to this vault's stack. Returns a descriptive error if any
+// required port is already occupied, or if Docker fails on non-zero exit.
 func StartStack(composePath, projectName string) error {
+	if err := checkPortsAvailable(); err != nil {
+		return err
+	}
 	return runDockerCompose(composePath, projectName, "up", "-d")
 }
 

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -82,7 +82,7 @@ func checkPorts(ports []int) error {
 		conn, err := net.DialTimeout("tcp", addr, time.Second)
 		if err == nil {
 			_ = conn.Close()
-			return fmt.Errorf("Port %d is already in use. Stop the current vault's audit stack with \"tegata ledger stop\" before starting another.", port)
+			return fmt.Errorf("Port %d is already in use. Stop the current vault's audit stack with \"tegata ledger stop\" before starting another.", port) //nolint:staticcheck // user-facing message requires sentence punctuation
 		}
 	}
 	return nil
@@ -123,7 +123,7 @@ func CheckLedgerAvailability(cfg config.AuditConfig) error {
 	if portErr := checkPortsAvailable(); portErr != nil {
 		return portErr
 	}
-	return fmt.Errorf("Audit stack is not running. Start it with \"tegata ledger start\".")
+	return fmt.Errorf("Audit stack is not running. Start it with \"tegata ledger start\".") //nolint:staticcheck // user-facing message requires sentence punctuation
 }
 
 // DockerBinPath returns the absolute path to the docker binary. It first

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -623,48 +623,58 @@ func EnsureStack(cfg config.AuditConfig, fsys fs.FS, progressFn func(string)) er
 	return nil
 }
 
+// RunAutoStart performs the Docker audit stack auto-start synchronously.
+// It syncs docker-compose.yml from fsys (when non-nil), starts the stack,
+// and waits for the ledger to become reachable. Returns an error on failure
+// so callers can route it through their own error channel rather than writing
+// to stderr. A nil return means the ledger is ready.
+// When cfg.DockerComposePath is empty or cfg.AutoStart is false, it is a no-op.
+func RunAutoStart(cfg config.AuditConfig, fsys fs.FS) error {
+	if cfg.DockerComposePath == "" || !cfg.AutoStart {
+		return nil
+	}
+	if fsys != nil {
+		if err := syncDockerCompose(fsys, cfg.DockerComposePath, cfg.DockerProjectName); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not sync docker-compose.yml: %v\n", err)
+		}
+	}
+	if err := ensureDockerDaemon(); err != nil {
+		return fmt.Errorf("docker daemon not ready: %w", err)
+	}
+	if err := StartStack(cfg.DockerComposePath, cfg.DockerProjectName); err != nil {
+		return err
+	}
+	for i := 0; i < autoStartRetries; i++ {
+		client, err := NewClientFromConfig(cfg)
+		if err != nil {
+			time.Sleep(autoStartInterval)
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		pingErr := client.Ping(ctx)
+		cancel()
+		_ = client.Close()
+		if pingErr == nil {
+			return nil
+		}
+		time.Sleep(autoStartInterval)
+	}
+	return fmt.Errorf("ledger did not become ready after %d attempts", autoStartRetries)
+}
+
 // MaybeAutoStart fires in a background goroutine when cfg.DockerComposePath
-// is non-empty. It runs docker compose up -d then retries Ping up to
-// autoStartRetries times. Non-blocking -- never panics, logs to stderr on
-// failure. Suitable for long-lived processes (TUI, GUI) where the goroutine
-// can complete after the unlock call returns. For short-lived CLI processes
-// use EnsureStack instead. Per D-10 and D-13.
-// fsys should be the embedded docker bundle FS (after fs.Sub). When non-nil,
-// docker-compose.yml is synced from the bundle before starting.
+// is non-empty. Non-blocking — never panics, logs to stderr on failure.
+// Suitable for non-TUI contexts (GUI, background CLI) where stderr output
+// is acceptable. For TUI processes use RunAutoStart via a tea.Cmd instead
+// so errors route through the message loop rather than corrupting the renderer.
+// Per D-10 and D-13.
 func MaybeAutoStart(cfg config.AuditConfig, fsys fs.FS) {
 	if cfg.DockerComposePath == "" || !cfg.AutoStart {
 		return
 	}
 	go func() {
-		if fsys != nil {
-			if err := syncDockerCompose(fsys, cfg.DockerComposePath, cfg.DockerProjectName); err != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "tegata: warning: could not sync docker-compose.yml: %v\n", err)
-			}
-		}
-		if err := ensureDockerDaemon(); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "tegata: audit auto-start: Docker daemon not ready: %v\n", err)
-			return
-		}
-		if err := StartStack(cfg.DockerComposePath, cfg.DockerProjectName); err != nil {
+		if err := RunAutoStart(cfg, fsys); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "tegata: audit auto-start failed: %v\n", err)
-			return
 		}
-		// Retry ping up to autoStartRetries times.
-		for i := 0; i < autoStartRetries; i++ {
-			client, err := NewClientFromConfig(cfg)
-			if err != nil {
-				time.Sleep(autoStartInterval)
-				continue
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			pingErr := client.Ping(ctx)
-			cancel()
-			_ = client.Close()
-			if pingErr == nil {
-				return
-			}
-			time.Sleep(autoStartInterval)
-		}
-		_, _ = fmt.Fprintf(os.Stderr, "tegata: audit ledger did not become ready after auto-start\n")
 	}()
 }

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -82,7 +82,7 @@ func checkPorts(ports []int) error {
 		conn, err := net.DialTimeout("tcp", addr, time.Second)
 		if err == nil {
 			_ = conn.Close()
-			return fmt.Errorf("port %d is already in use. Stop the current vault's audit stack with 'tegata ledger stop' before starting another", port)
+			return fmt.Errorf("port %d is already in use. Stop the current vault's audit stack with \"tegata ledger stop\" before starting another.", port)
 		}
 	}
 	return nil
@@ -123,7 +123,7 @@ func CheckLedgerAvailability(cfg config.AuditConfig) error {
 	if portErr := checkPortsAvailable(); portErr != nil {
 		return portErr
 	}
-	return fmt.Errorf("audit stack is not running. Start it with 'tegata ledger start'")
+	return fmt.Errorf("audit stack is not running. Start it with \"tegata ledger start\".")
 }
 
 // DockerBinPath returns the absolute path to the docker binary. It first

--- a/internal/audit/docker.go
+++ b/internal/audit/docker.go
@@ -85,6 +85,44 @@ func checkPorts(ports []int) error {
 	return nil
 }
 
+// isDockerProjectRunning returns true when at least one container for the
+// given Docker Compose project is currently running. It queries Docker
+// directly using the com.docker.compose.project label rather than parsing
+// compose output, so it works across Docker Compose v2 versions. Returns
+// false when composePath doesn't exist, projectName is empty, or Docker is
+// not available — all safe defaults that let callers fall through to startup.
+func isDockerProjectRunning(composePath, projectName string) bool {
+	if composePath == "" || projectName == "" {
+		return false
+	}
+	if _, err := os.Stat(composePath); err != nil {
+		return false
+	}
+	label := "com.docker.compose.project=" + projectName
+	out, err := dockerCmd("ps", "--filter", "label="+label, "--quiet").Output()
+	return err == nil && len(strings.TrimSpace(string(out))) > 0
+}
+
+// CheckLedgerAvailability verifies that the audit ledger is accessible for
+// the given config before a query is made. When DockerComposePath is set,
+// it checks whether this vault's Docker project is actually running (not a
+// different vault's stack that happens to occupy the same ports). Returns a
+// descriptive error if the stack is absent or a port conflict is detected.
+// When DockerComposePath is empty the ledger is assumed to be externally
+// managed and no Docker check is performed.
+func CheckLedgerAvailability(cfg config.AuditConfig) error {
+	if cfg.DockerComposePath == "" {
+		return nil
+	}
+	if isDockerProjectRunning(cfg.DockerComposePath, cfg.DockerProjectName) {
+		return nil
+	}
+	if portErr := checkPortsAvailable(); portErr != nil {
+		return portErr
+	}
+	return fmt.Errorf("audit stack is not running. Start it with 'tegata ledger start'")
+}
+
 // DockerBinPath returns the absolute path to the docker binary. It first
 // checks PATH (via LookPath), then falls back to known macOS and Linux
 // locations. Returns an empty string if docker cannot be found. Exported
@@ -594,14 +632,19 @@ func EnsureStack(cfg config.AuditConfig, fsys fs.FS, progressFn func(string)) er
 		}
 	}
 
-	// Quick probe: ledger already reachable — nothing to do.
-	if client, err := NewClientFromConfig(cfg); err == nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		pingErr := client.Ping(ctx)
-		cancel()
-		_ = client.Close()
-		if pingErr == nil {
-			return nil
+	// Quick probe: only skip startup when THIS vault's Docker project is
+	// confirmed running. Without the project check, the ping could succeed
+	// against a different vault's stack on the same ports, causing subsequent
+	// queries to silently target the wrong entity and return no events.
+	if isDockerProjectRunning(cfg.DockerComposePath, cfg.DockerProjectName) {
+		if client, err := NewClientFromConfig(cfg); err == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			pingErr := client.Ping(ctx)
+			cancel()
+			_ = client.Close()
+			if pingErr == nil {
+				return nil
+			}
 		}
 	}
 

--- a/internal/audit/docker_test.go
+++ b/internal/audit/docker_test.go
@@ -253,7 +253,7 @@ func TestCheckPorts_PortInUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	err = checkPorts([]int{port})
@@ -284,12 +284,12 @@ func TestCheckPorts_FirstConflictReported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen ln1: %v", err)
 	}
-	defer ln1.Close()
+	defer func() { _ = ln1.Close() }()
 	ln2, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen ln2: %v", err)
 	}
-	defer ln2.Close()
+	defer func() { _ = ln2.Close() }()
 
 	port1 := ln1.Addr().(*net.TCPAddr).Port
 	port2 := ln2.Addr().(*net.TCPAddr).Port

--- a/internal/audit/docker_test.go
+++ b/internal/audit/docker_test.go
@@ -249,7 +249,7 @@ func TestCheckLedgerAvailability_NoDockerPath(t *testing.T) {
 // TestCheckPorts_PortInUse verifies that checkPorts returns a descriptive error
 // when a port is already bound.
 func TestCheckPorts_PortInUse(t *testing.T) {
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestCheckPorts_PortInUse(t *testing.T) {
 	if err == nil {
 		t.Fatal("checkPorts: expected error when port is in use, got nil")
 	}
-	want := fmt.Sprintf("port %d is already in use", port)
+	want := fmt.Sprintf("Port %d is already in use", port)
 	if !strings.Contains(err.Error(), want) {
 		t.Errorf("checkPorts error = %q, want to contain %q", err.Error(), want)
 	}
@@ -280,12 +280,12 @@ func TestCheckPorts_PortFree(t *testing.T) {
 // TestCheckPorts_FirstConflictReported verifies that checkPorts reports the
 // first conflicting port, not a later one, so the error is deterministic.
 func TestCheckPorts_FirstConflictReported(t *testing.T) {
-	ln1, err := net.Listen("tcp", "localhost:0")
+	ln1, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen ln1: %v", err)
 	}
 	defer ln1.Close()
-	ln2, err := net.Listen("tcp", "localhost:0")
+	ln2, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen ln2: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestCheckPorts_FirstConflictReported(t *testing.T) {
 	if err == nil {
 		t.Fatal("checkPorts: expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), fmt.Sprintf("port %d", port1)) {
+	if !strings.Contains(err.Error(), fmt.Sprintf("Port %d", port1)) {
 		t.Errorf("checkPorts error = %q, want to mention first port %d", err.Error(), port1)
 	}
 }

--- a/internal/audit/docker_test.go
+++ b/internal/audit/docker_test.go
@@ -218,6 +218,34 @@ func TestSyncDockerCompose_RewritesVolume(t *testing.T) {
 	})
 }
 
+// TestIsDockerProjectRunning_NoComposeFile verifies that isDockerProjectRunning
+// returns false when the compose file does not exist (project was never set up).
+func TestIsDockerProjectRunning_NoComposeFile(t *testing.T) {
+	if isDockerProjectRunning("/nonexistent/docker-compose.yml", "some-project") {
+		t.Error("isDockerProjectRunning: expected false for nonexistent compose file, got true")
+	}
+}
+
+// TestIsDockerProjectRunning_EmptyArgs verifies that isDockerProjectRunning
+// returns false when composePath or projectName is empty.
+func TestIsDockerProjectRunning_EmptyArgs(t *testing.T) {
+	if isDockerProjectRunning("", "project") {
+		t.Error("isDockerProjectRunning: expected false for empty composePath")
+	}
+	if isDockerProjectRunning("/some/path", "") {
+		t.Error("isDockerProjectRunning: expected false for empty projectName")
+	}
+}
+
+// TestCheckLedgerAvailability_NoDockerPath verifies that CheckLedgerAvailability
+// is a no-op when DockerComposePath is empty (externally managed ledger).
+func TestCheckLedgerAvailability_NoDockerPath(t *testing.T) {
+	cfg := config.AuditConfig{DockerComposePath: ""}
+	if err := CheckLedgerAvailability(cfg); err != nil {
+		t.Errorf("CheckLedgerAvailability with no compose path: unexpected error: %v", err)
+	}
+}
+
 // TestCheckPorts_PortInUse verifies that checkPorts returns a descriptive error
 // when a port is already bound.
 func TestCheckPorts_PortInUse(t *testing.T) {

--- a/internal/audit/docker_test.go
+++ b/internal/audit/docker_test.go
@@ -2,6 +2,8 @@ package audit
 
 import (
 	"bytes"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -214,6 +216,63 @@ func TestSyncDockerCompose_RewritesVolume(t *testing.T) {
 			t.Errorf("expected original volume name in output: %s", got)
 		}
 	})
+}
+
+// TestCheckPorts_PortInUse verifies that checkPorts returns a descriptive error
+// when a port is already bound.
+func TestCheckPorts_PortInUse(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	err = checkPorts([]int{port})
+	if err == nil {
+		t.Fatal("checkPorts: expected error when port is in use, got nil")
+	}
+	want := fmt.Sprintf("port %d is already in use", port)
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("checkPorts error = %q, want to contain %q", err.Error(), want)
+	}
+	if !strings.Contains(err.Error(), "tegata ledger stop") {
+		t.Errorf("checkPorts error = %q, want to mention 'tegata ledger stop'", err.Error())
+	}
+}
+
+// TestCheckPorts_PortFree verifies that checkPorts returns nil when the port
+// list is empty (no ports to check).
+func TestCheckPorts_PortFree(t *testing.T) {
+	if err := checkPorts(nil); err != nil {
+		t.Errorf("checkPorts(nil): unexpected error: %v", err)
+	}
+}
+
+// TestCheckPorts_FirstConflictReported verifies that checkPorts reports the
+// first conflicting port, not a later one, so the error is deterministic.
+func TestCheckPorts_FirstConflictReported(t *testing.T) {
+	ln1, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen ln1: %v", err)
+	}
+	defer ln1.Close()
+	ln2, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen ln2: %v", err)
+	}
+	defer ln2.Close()
+
+	port1 := ln1.Addr().(*net.TCPAddr).Port
+	port2 := ln2.Addr().(*net.TCPAddr).Port
+
+	err = checkPorts([]int{port1, port2})
+	if err == nil {
+		t.Fatal("checkPorts: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("port %d", port1)) {
+		t.Errorf("checkPorts error = %q, want to mention first port %d", err.Error(), port1)
+	}
 }
 
 // TestMaybeAutoStart_NoPath verifies that auto-start is a no-op when


### PR DESCRIPTION
## Summary

This PR detects port conflicts when a second vault's audit Docker stack is started, surfaces actionable errors in the CLI, TUI, and GUI instead of raw Docker errors or silent wrong-ledger queries, and routes auto-start errors through the TUI message loop to prevent terminal corruption.

## Related issues or PRs

- Resolves #93

## Changes made

- Add `checkPorts`/`checkPortsAvailable` to probe TCP ports 5432, 50051, and 50052 before calling `docker compose up`, returning a human-readable error naming the conflicting port
- Add `isDockerProjectRunning` (using `docker ps --filter label=com.docker.compose.project=<name>`) to verify a specific vault's containers are running before accepting a ledger ping as valid
- Add `CheckLedgerAvailability` to detect port conflicts and wrong-ledger situations before any history/verify query is attempted
- Add `RunAutoStart` as a synchronous, error-returning alternative to `MaybeAutoStart` for use in contexts where errors must be routed through a message channel
- Replace fire-and-forget `MaybeAutoStart` call in the TUI unlock path with a `tea.Cmd` (`maybeAutoStartCmd`) that returns an `auditAutoStartMsg`, routing errors to `statusMsg` instead of raw stderr writes
- Guard `EnsureStack`'s quick probe with `isDockerProjectRunning` so it no longer accepts a ping from a different vault's ledger on the same ports
- Apply `CheckLedgerAvailability` in `auditHistoryCmd`, `auditVerifyCmd` (TUI), `tegata history`, `tegata verify` (CLI), and `GetAuditHistory`, `VerifyAuditLog`, `VerifyCredentialAuditLog` (GUI)
- Fix `checkPorts` to dial `127.0.0.1` instead of `localhost`, which on macOS resolves to `::1` (IPv6) while Docker Desktop binds ports to `127.0.0.1` (IPv4) only

## Technical implementation

- **Approach:** Lightweight TCP dial (`net.DialTimeout`) for port conflict detection; Docker label query (`docker ps --filter label=...`) for project identity verification — both are fast and require no Docker Compose parsing
- **Key components modified:** `internal/audit/docker.go`, `cmd/tegata/tui_unlock.go`, `cmd/tegata/tui_model.go`, `cmd/tegata/tui_overlay_audit.go`, `cmd/tegata/history.go`, `cmd/tegata/verify.go`, `cmd/tegata-gui/app.go`
- **Dependencies added/removed:** None
- **Design patterns used:** Error returned from `CheckLedgerAvailability` before any gRPC client is created; bubbletea `tea.Cmd` for routing async errors through the message loop

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [x] Builds successfully on Windows (amd64)
- [ ] Builds successfully on Linux (amd64)
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] CLI commands tested manually with expected inputs
- [x] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable)
- [ ] ScalarDL integration tested (if applicable)
- [ ] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- not applicable – no authentication/authorization logic changed

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes

## Additional context

The `localhost` vs `127.0.0.1` issue affects macOS specifically: `localhost` resolves to `::1` (IPv6) in DNS while Docker Desktop binds published ports to `127.0.0.1` (IPv4) only. This caused `checkPorts` to always report ports as free even with running containers, meaning port conflict detection silently failed. The same behavior is already documented and worked around in `writeClientProperties` elsewhere in `docker.go`.