### PR TITLE
Fix ledger setup curl retry and queue.tegata vault filter

### DIFF
--- a/cmd/tegata-gui/docker-bundle/docker-compose.yml
+++ b/cmd/tegata-gui/docker-bundle/docker-compose.yml
@@ -103,7 +103,7 @@ services:
         set -e
         apk add --no-cache curl unzip netcat-openbsd
         echo "Downloading ScalarDL HashStore SDK..."
-        curl -fsSL -O https://github.com/scalar-labs/scalardl/releases/download/v3.13.0/scalardl-hashstore-java-client-sdk-3.13.0.zip
+        curl -fsSL --retry 5 --retry-delay 5 -O https://github.com/scalar-labs/scalardl/releases/download/v3.13.0/scalardl-hashstore-java-client-sdk-3.13.0.zip
         echo "6ec6f354b99fb4910980a154bc4ca42690f2f24feef8367cee37843378bb0d84  scalardl-hashstore-java-client-sdk-3.13.0.zip" | sha256sum -c
         unzip -qo scalardl-hashstore-java-client-sdk-3.13.0.zip
         echo "Waiting for ledger to accept connections..."

--- a/cmd/tegata-gui/drives.go
+++ b/cmd/tegata-gui/drives.go
@@ -85,7 +85,8 @@ func scanMountedDrives() []VaultLocation {
 }
 
 // findVaultsInDir returns VaultLocation entries for all *.tegata files in dir,
-// skipping macOS resource fork files (names starting with "._").
+// skipping macOS resource fork files (names starting with "._") and known
+// non-vault .tegata files such as queue.tegata.
 func findVaultsInDir(dir, driveName string) []VaultLocation {
 	var results []VaultLocation
 	entries, err := os.ReadDir(dir)
@@ -98,6 +99,10 @@ func findVaultsInDir(dir, driveName string) []VaultLocation {
 		}
 		name := e.Name()
 		if strings.HasPrefix(name, "._") {
+			continue
+		}
+		// Skip queue.tegata — it is the offline audit event queue, not a vault.
+		if strings.ToLower(name) == "queue.tegata" {
 			continue
 		}
 		if strings.HasSuffix(strings.ToLower(name), vaultExtension) {

--- a/cmd/tegata-gui/drives_test.go
+++ b/cmd/tegata-gui/drives_test.go
@@ -100,3 +100,23 @@ func TestFindVaultsInDir_FiltersMacOSMetadata(t *testing.T) {
 		t.Errorf("expected vault.tegata, got %q", filepath.Base(results[0].Path))
 	}
 }
+
+func TestFindVaultsInDir_FiltersQueueFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a vault file and the offline audit queue file.
+	if err := os.WriteFile(filepath.Join(dir, "vault.tegata"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "queue.tegata"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	results := findVaultsInDir(dir, "USB")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 vault (queue.tegata excluded), got %d", len(results))
+	}
+	if filepath.Base(results[0].Path) != "vault.tegata" {
+		t.Errorf("expected vault.tegata, got %q", filepath.Base(results[0].Path))
+	}
+}

--- a/cmd/tegata-gui/drives_test.go
+++ b/cmd/tegata-gui/drives_test.go
@@ -102,21 +102,25 @@ func TestFindVaultsInDir_FiltersMacOSMetadata(t *testing.T) {
 }
 
 func TestFindVaultsInDir_FiltersQueueFile(t *testing.T) {
-	dir := t.TempDir()
+	cases := []string{"queue.tegata", "Queue.Tegata", "QUEUE.TEGATA"}
+	for _, queueName := range cases {
+		t.Run(queueName, func(t *testing.T) {
+			dir := t.TempDir()
 
-	// Create a vault file and the offline audit queue file.
-	if err := os.WriteFile(filepath.Join(dir, "vault.tegata"), []byte("x"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "queue.tegata"), []byte("x"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+			if err := os.WriteFile(filepath.Join(dir, "vault.tegata"), []byte("x"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, queueName), []byte("x"), 0o600); err != nil {
+				t.Fatal(err)
+			}
 
-	results := findVaultsInDir(dir, "USB")
-	if len(results) != 1 {
-		t.Fatalf("expected 1 vault (queue.tegata excluded), got %d", len(results))
-	}
-	if filepath.Base(results[0].Path) != "vault.tegata" {
-		t.Errorf("expected vault.tegata, got %q", filepath.Base(results[0].Path))
+			results := findVaultsInDir(dir, "USB")
+			if len(results) != 1 {
+				t.Fatalf("expected 1 vault (%s excluded), got %d", queueName, len(results))
+			}
+			if filepath.Base(results[0].Path) != "vault.tegata" {
+				t.Errorf("expected vault.tegata, got %q", filepath.Base(results[0].Path))
+			}
+		})
 	}
 }

--- a/cmd/tegata/docker-bundle/docker-compose.yml
+++ b/cmd/tegata/docker-bundle/docker-compose.yml
@@ -103,7 +103,7 @@ services:
         set -e
         apk add --no-cache curl unzip netcat-openbsd
         echo "Downloading ScalarDL HashStore SDK..."
-        curl -fsSL -O https://github.com/scalar-labs/scalardl/releases/download/v3.13.0/scalardl-hashstore-java-client-sdk-3.13.0.zip
+        curl -fsSL --retry 5 --retry-delay 5 -O https://github.com/scalar-labs/scalardl/releases/download/v3.13.0/scalardl-hashstore-java-client-sdk-3.13.0.zip
         echo "6ec6f354b99fb4910980a154bc4ca42690f2f24feef8367cee37843378bb0d84  scalardl-hashstore-java-client-sdk-3.13.0.zip" | sha256sum -c
         unzip -qo scalardl-hashstore-java-client-sdk-3.13.0.zip
         echo "Waiting for ledger to accept connections..."

--- a/deployments/docker-compose/docker-compose.yml
+++ b/deployments/docker-compose/docker-compose.yml
@@ -100,7 +100,7 @@ services:
         set -e
         apk add --no-cache curl unzip netcat-openbsd
         echo "Downloading ScalarDL HashStore SDK..."
-        curl -fsSL -O https://github.com/scalar-labs/scalardl/releases/download/v3.13.0/scalardl-hashstore-java-client-sdk-3.13.0.zip
+        curl -fsSL --retry 5 --retry-delay 5 -O https://github.com/scalar-labs/scalardl/releases/download/v3.13.0/scalardl-hashstore-java-client-sdk-3.13.0.zip
         echo "6ec6f354b99fb4910980a154bc4ca42690f2f24feef8367cee37843378bb0d84  scalardl-hashstore-java-client-sdk-3.13.0.zip" | sha256sum -c
         unzip -qo scalardl-hashstore-java-client-sdk-3.13.0.zip
         echo "Waiting for ledger to accept connections..."


### PR DESCRIPTION
## Summary

This PR fixes two bugs: a transient network failure that causes the Docker ledger setup to fail with exit code 56, and `queue.tegata` appearing as a selectable vault in the GUI.

## Related issues or PRs

- N/A

## Changes made

- Add `--retry 5 --retry-delay 5` to the `curl` download command in all three `docker-compose.yml` files (`cmd/tegata/docker-bundle/`, `cmd/tegata-gui/docker-bundle/`, `deployments/docker-compose/`)
- Exclude `queue.tegata` from `findVaultsInDir` in `cmd/tegata-gui/drives.go` so the offline audit queue file is not offered as a selectable vault
- Add `TestFindVaultsInDir_FiltersQueueFile` test to cover the new exclusion

## Technical implementation

- **Approach:** curl's `--retry` flag explicitly handles exit code 56 (`CURLE_RECV_ERROR`) as a transient error. Adding `--retry 5 --retry-delay 5` gives the SDK download five extra attempts (5 s apart) before failing. For the vault filter, a simple `strings.ToLower(name) == "queue.tegata"` check before the extension match is sufficient.
- **Key components modified:** all three `docker-compose.yml` embeds; `cmd/tegata-gui/drives.go`; `cmd/tegata-gui/drives_test.go`
- **Dependencies added/removed:** none
- **Design patterns used:** defensive retry for external network calls; explicit exclusion list for known non-vault `.tegata` files

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [x] Builds successfully on Windows (amd64)
- [ ] Builds successfully on Linux (amd64)
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] CLI commands tested manually with expected inputs
- [ ] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable)
- [ ] ScalarDL integration tested (if applicable)
- [ ] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [x] Cryptographic operations use secure, well-tested libraries
- [x] Memory is zeroed after handling sensitive data
- [x] Input validation implemented for all user-provided data
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable) — not applicable

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable) — not applicable

## Breaking changes

- [x] No breaking changes

## Additional context

The ledger setup failure manifests as:

```
Audit setup failed: contract registration: bootstrap container exited with error: exit status 56
container "<hash>" exited with status code 56
```

Exit code 56 is `CURLE_RECV_ERROR` — a transient network failure while receiving data during the GitHub SDK download inside the `scalardl-contract-registration` container. The container already has `restart: on-failure:3`, but `docker compose wait` observes the final exit code after all restarts; the retry at the curl level means each restart attempt is itself resilient to flaky network conditions.

The `queue.tegata` issue occurs because the offline audit event queue shares the `.tegata` extension with vault files, causing it to appear alongside actual vaults in the GUI drive scan.