### PR TITLE
Fix macOS app bundle binary losing executable permissions after artifact download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,12 @@ jobs:
           cp -R "$APP_PATH" gui-app/
           echo "Normalized app to: gui-app/$(basename "$APP_PATH")"
 
+          # Restore executable permissions lost during artifact upload/download.
+          # actions/upload-artifact does not preserve file permissions, so binaries
+          # inside the app bundle arrive as 644 and must be made executable before
+          # signing, otherwise macOS refuses to launch the app.
+          find "gui-app/$(basename "$APP_PATH")/Contents/MacOS" -type f -exec chmod +x {} \;
+
       - name: Setup signing keychain
         env:
           CERTIFICATE_P12: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}


### PR DESCRIPTION
## Summary

This PR fixes the issue where Tegata.app cannot be opened on macOS after installation from the DMG, showing "The application 'Tegata' can't be opened.".

## Related issues or PRs

- N/A

## Changes made

- Added `chmod +x` on all binaries in `Contents/MacOS/` immediately after copying the app bundle from the downloaded artifact in the `macos-signing` CI job.

## Technical implementation

- **Approach:** `actions/upload-artifact` does not preserve file permissions. The `tegata-gui` binary inside the app bundle is downloaded as `644` instead of `755`. macOS checks execute permissions when launching an app — even a fully signed and notarized one — so the binary must be made executable before packaging into the DMG. The `chmod` is applied in the "Normalize GUI app location" step, before code signing, which does not affect signature validity (codesign seals file contents, not permissions).
- **Key components modified:** `.github/workflows/release.yml`
- **Dependencies added/removed:** None
- **Design patterns used:** N/A

## Testing performed

- [ ] Builds successfully on macOS (arm64)
- [ ] Builds successfully on Windows (amd64)
- [ ] Builds successfully on Linux (amd64)
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] CLI commands tested manually with expected inputs — confirmed root cause: `/Applications/Tegata.app/Contents/MacOS/tegata-gui` had `644` permissions; `chmod +x` fixes launch immediately
- [ ] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable) — not applicable
- [ ] ScalarDL integration tested (if applicable) — not applicable
- [ ] Cross-platform compatibility verified (if applicable) — macOS-only change

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [ ] Cryptographic operations use secure, well-tested libraries — not applicable
- [ ] Memory is zeroed after handling sensitive data — not applicable
- [ ] Input validation implemented for all user-provided data — not applicable
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected — not modified
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable) — not applicable

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic — added inline comment explaining why `chmod` is needed
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages — not applicable
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions — not applicable
- [x] Dependencies pinned to specific versions — not applicable
- [ ] Documentation updated (README, user guides, API docs if applicable) — not applicable

## Breaking changes

- [x] No breaking changes

## Additional context

Users who downloaded the current release can fix their existing installation immediately with:
```bash
chmod +x /Applications/Tegata.app/Contents/MacOS/tegata-gui
```
This does not invalidate the notarized signature since codesign seals file contents, not permissions.