### PR TITLE
Add direct download links for latest release assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,25 @@ The optional ScalarDL Ledger integration provides tamper-evident audit logging, 
 
 Tegata can be installed using pre-built binaries or built from source.
 
-To download the pre-built binary for your operating system, see the [Releases](https://github.com/josh-wong/tegata/releases) page.
+Download the pre-built CLI binary for your operating system:
+
+- **Windows:** [tegata-windows-amd64.exe](https://github.com/josh-wong/tegata/releases/latest/download/tegata-windows-amd64.exe)
+- **macOS (Apple Silicon):** [tegata-darwin-arm64](https://github.com/josh-wong/tegata/releases/latest/download/tegata-darwin-arm64)
+- **macOS (Intel):** [tegata-darwin-amd64](https://github.com/josh-wong/tegata/releases/latest/download/tegata-darwin-amd64)
+- **Linux:** [tegata-linux-amd64](https://github.com/josh-wong/tegata/releases/latest/download/tegata-linux-amd64)
 
 > [!IMPORTANT]
 > 
 > On macOS and Linux, mark the binary as executable with `chmod +x`.
 
-For GUI downloads, use the platform-specific release artifacts on the same page:
+For the optional desktop GUI:
 
-- **Windows:** `tegata-gui-windows-amd64-setup.exe`
-- **macOS:** `tegata-gui-darwin-universal.dmg`
-- **Linux:** `tegata-gui-linux-amd64.deb` or `tegata-gui-linux-amd64.rpm`
+- **Windows:** [tegata-gui-windows-amd64-setup.exe](https://github.com/josh-wong/tegata/releases/latest/download/tegata-gui-windows-amd64-setup.exe)
+- **macOS:** [tegata-gui-darwin-universal.dmg](https://github.com/josh-wong/tegata/releases/latest/download/tegata-gui-darwin-universal.dmg)
+- **Linux (.deb):** [tegata-gui-linux-amd64.deb](https://github.com/josh-wong/tegata/releases/latest/download/tegata-gui-linux-amd64.deb)
+- **Linux (.rpm):** [tegata-gui-linux-amd64.rpm](https://github.com/josh-wong/tegata/releases/latest/download/tegata-gui-linux-amd64.rpm)
+
+All links above always resolve to the latest release. For a full list of release assets, see the [Releases](https://github.com/josh-wong/tegata/releases) page.
 
 > [!NOTE]
 > 

--- a/site/docs/quickstart.mdx
+++ b/site/docs/quickstart.mdx
@@ -24,7 +24,7 @@ Before you begin, you need the following:
 <Tabs groupId="os" queryString>
   <TabItem value="windows" label="Windows" default>
 
-Download `tegata-windows-amd64.exe` from the [Releases](https://github.com/josh-wong/tegata/releases) page. Rename it to `tegata.exe` and copy it to your USB drive.
+Download [tegata-windows-amd64.exe](https://github.com/josh-wong/tegata/releases/latest/download/tegata-windows-amd64.exe). Rename it to `tegata.exe` and copy it to your USB drive.
 
 Open PowerShell. Since PowerShell does not search the current directory for executables, run the following command to run the binary by prefixing it with `.\`:
 
@@ -41,16 +41,16 @@ $env:PATH += ";<USB_DRIVE_LETTER>:\"
   </TabItem>
   <TabItem value="macos" label="macOS">
 
-Download the binary for your Mac from the [Releases](https://github.com/josh-wong/tegata/releases) page.
+Download the binary for your Mac:
 
-- `tegata-darwin-arm64` for Apple Silicon (M1 and later)
-- `tegata-darwin-amd64` for Intel
+- [tegata-darwin-arm64](https://github.com/josh-wong/tegata/releases/latest/download/tegata-darwin-arm64) for Apple Silicon (M1 and later)
+- [tegata-darwin-amd64](https://github.com/josh-wong/tegata/releases/latest/download/tegata-darwin-amd64) for Intel
 
 Make the binary executable and copy it to your USB drive by running the following commands, replacing `<USB_DRIVE_NAME>` with the actual name of your drive:
 
 ```bash
-chmod +x tegata-darwin-arm64 # or chmod +x tegata-darwin-amd64 for Macs with Intel processors
-cp tegata-darwin-arm64 /Volumes/<USB_DRIVE_NAME>/tegata # or cp tegata-darwin-amd64 /Volumes/<USB_DRIVE_NAME>/tegata for Macs with Intel processors
+chmod +x tegata-darwin-arm64 # Or chmod +x tegata-darwin-amd64 for Macs with Intel processors
+cp tegata-darwin-arm64 /Volumes/<USB_DRIVE_NAME>/tegata # Or cp tegata-darwin-amd64 /Volumes/<USB_DRIVE_NAME>/tegata for Macs with Intel processors
 ```
 
 :::warning[macOS Gatekeeper]
@@ -68,13 +68,12 @@ Linux has not been manually tested. These steps are expected to work, but if you
 
 :::
 
-Download `tegata-linux-amd64` from the [Releases](https://github.com/josh-wong/tegata/releases) page. Then, make the file executable and copy it to your USB drive by running the following commands, replacing `<USB_DRIVE_NAME>` with the actual name of your drive:
+Download [tegata-linux-amd64](https://github.com/josh-wong/tegata/releases/latest/download/tegata-linux-amd64). Then, make the file executable and copy it to your USB drive by running the following commands, replacing `<USB_DRIVE_NAME>` with the actual name of your drive:
 
 ```bash
 chmod +x tegata-linux-amd64
 cp tegata-linux-amd64 /media/$USER/<USB_DRIVE_NAME>/tegata
 ```
-
   </TabItem>
 </Tabs>
 
@@ -82,12 +81,16 @@ cp tegata-linux-amd64 /media/$USER/<USB_DRIVE_NAME>/tegata
 
 A graphical interface is available separately and is installed on your host machine rather than carried on the USB drive.
 
+:::note[Troubleshooting]
+
 If the GUI or CLI does not launch on first run, check [Set up your OS](os-setup.mdx) and [Troubleshooting](troubleshooting.mdx) for platform-specific fixes.
+
+:::
 
 <Tabs groupId="os" queryString>
   <TabItem value="windows" label="Windows" default>
 
-Download and run `tegata-gui-windows-amd64-setup.exe`. The NSIS installer places the binary in `Program Files` and creates a Start Menu entry.
+Download and run [tegata-gui-windows-amd64-setup.exe](https://github.com/josh-wong/tegata/releases/latest/download/tegata-gui-windows-amd64-setup.exe). The NSIS installer places the binary in `Program Files` and creates a Start Menu entry.
 
 :::note
 
@@ -97,7 +100,7 @@ If SmartScreen blocks first launch, select **More info**, then choose **Run anyw
   </TabItem>
   <TabItem value="macos" label="macOS">
 
-Download `tegata-gui-darwin-universal.dmg`. Open the disk image and drag Tegata to your Applications folder.
+Download [tegata-gui-darwin-universal.dmg](https://github.com/josh-wong/tegata/releases/latest/download/tegata-gui-darwin-universal.dmg). Open the disk image and drag Tegata to your Applications folder.
 
 :::note
 


### PR DESCRIPTION
## Summary

This PR replaces generic [Releases page](https://github.com/josh-wong/tegata/releases) references in the quickstart and README with direct download links using GitHub's `/releases/latest/download/` URL pattern, which always resolves to the matching asset from the most recent release.

## Related issues or PRs

N/A

## Changes made

- Updated `README.md` to list per-platform CLI and GUI download links using `/releases/latest/download/` URLs
- Updated `site/docs/quickstart.mdx` to turn each binary filename into a direct download link using the same URL pattern
- Retained a link to the full Releases page in `README.md` for users who want to browse all assets

## Technical implementation

- **Approach:** GitHub's `https://github.com/{owner}/{repo}/releases/latest/download/{asset-name}` URL automatically redirects to the matching file from the release tagged as Latest. No tooling or scripting needed — links are permanent as long as asset filenames remain consistent across releases.
- **Key components modified:** `README.md`, `site/docs/quickstart.mdx`
- **Dependencies added/removed:** None
- **Design patterns used:** N/A

## Testing performed

- [ ] Builds successfully on macOS (arm64) — not applicable, docs only
- [ ] Builds successfully on Windows (amd64) — not applicable, docs only
- [ ] Builds successfully on Linux (amd64) — not applicable, docs only
- [ ] Unit tests pass — not applicable, docs only
- [ ] Integration tests pass (if applicable) — not applicable, docs only
- [ ] CLI commands tested manually with expected inputs — not applicable, docs only
- [ ] Edge cases and error handling tested (invalid inputs, missing files, permission errors) — not applicable, docs only
- [ ] Cryptographic operations verified (if applicable) — not applicable, docs only
- [ ] ScalarDL integration tested (if applicable) — not applicable, docs only
- [ ] Cross-platform compatibility verified (if applicable) — not applicable, docs only

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [ ] Cryptographic operations use secure, well-tested libraries — not applicable, docs only
- [ ] Memory is zeroed after handling sensitive data — not applicable, docs only
- [ ] Input validation implemented for all user-provided data — not applicable, docs only
- [ ] No SQL injection, command injection, or path traversal vulnerabilities — not applicable, docs only
- [ ] Error messages don't leak sensitive information — not applicable, docs only
- [ ] Vault files remain encrypted and properly protected — not applicable, docs only
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable) — not applicable, docs only

## Code quality

- [ ] Code follows project conventions (Go style guidelines) — not applicable, docs only
- [ ] Added appropriate comments for complex cryptographic or security logic — not applicable, docs only
- [x] No hardcoded secrets or configuration values
- [ ] Proper error handling and user-friendly error messages — not applicable, docs only
- [ ] No debugging code or print/println statements left in — not applicable, docs only
- [ ] Removed unused imports, variables, and functions — not applicable, docs only
- [ ] Dependencies pinned to specific versions — not applicable, docs only
- [x] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes

## Additional context

The `/releases/latest/download/` pattern is a standard GitHub feature. Links will continue to work for future releases as long as asset filenames stay consistent (e.g., `tegata-windows-amd64.exe` remains the Windows CLI artifact name).