### PR TITLE
Add support links to settings and one-time support banner

### DIFF
--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -211,9 +212,13 @@ func (a *App) UnlockVault(path, passphrase string) error {
 	}
 	a.config = cfg
 
-	// Increment unlock count for the support banner threshold; failure is non-fatal.
+	// Read, increment, and store the unlock count in the encrypted vault so it
+	// cannot be manipulated by editing tegata.toml. Failure is non-fatal.
+	if n, err := strconv.Atoi(a.vault.GetSecret("ui.unlock_count")); err == nil {
+		a.config.UI.UnlockCount = n
+	}
 	a.config.UI.UnlockCount++
-	_ = config.WriteUI(vaultDir(a.vaultPath), a.config.UI.UnlockCount, a.config.UI.SupportBannerDismissed)
+	_ = a.vault.SetSecret("ui.unlock_count", strconv.Itoa(a.config.UI.UnlockCount))
 
 	// Attempt to load HMAC secret from vault (encrypted storage).
 	secretFromVault := a.vault.GetSecret("audit.secret_key")
@@ -1025,9 +1030,10 @@ func (a *App) SetLanguage(lang string) error {
 	return nil
 }
 
-// GetSupportBannerVisible returns true when the one-time support banner should
-// be displayed: the vault has been unlocked at least 10 times and the user has
-// not yet dismissed the banner.
+// GetSupportBannerVisible returns true when the support banner should be
+// displayed: the vault has been unlocked a positive multiple of 10 times and
+// the user has not permanently dismissed the banner. The unlock count is stored
+// in the encrypted vault and cannot be manipulated via tegata.toml.
 func (a *App) GetSupportBannerVisible() bool {
 	const interval = 10
 	return a.config.UI.UnlockCount > 0 &&
@@ -1042,7 +1048,7 @@ func (a *App) DismissSupportBanner() error {
 	if a.vaultPath == "" {
 		return fmt.Errorf("vault is not open")
 	}
-	if err := config.WriteUI(vaultDir(a.vaultPath), a.config.UI.UnlockCount, true); err != nil {
+	if err := config.WriteUI(vaultDir(a.vaultPath), true); err != nil {
 		return fmt.Errorf("saving support banner state: %w", err)
 	}
 	return nil

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -1029,8 +1029,10 @@ func (a *App) SetLanguage(lang string) error {
 // be displayed: the vault has been unlocked at least 10 times and the user has
 // not yet dismissed the banner.
 func (a *App) GetSupportBannerVisible() bool {
-	const threshold = 10
-	return a.config.UI.UnlockCount >= threshold && !a.config.UI.SupportBannerDismissed
+	const interval = 10
+	return a.config.UI.UnlockCount > 0 &&
+		a.config.UI.UnlockCount%interval == 0 &&
+		!a.config.UI.SupportBannerDismissed
 }
 
 // DismissSupportBanner marks the support banner as permanently dismissed and

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -212,8 +212,8 @@ func (a *App) UnlockVault(path, passphrase string) error {
 	a.config = cfg
 
 	// Increment unlock count for the support banner threshold; failure is non-fatal.
-	a.config.LaunchCount++
-	_ = config.WriteUI(vaultDir(a.vaultPath), a.config.LaunchCount, a.config.SupportBannerDismissed)
+	a.config.UI.UnlockCount++
+	_ = config.WriteUI(vaultDir(a.vaultPath), a.config.UI.UnlockCount, a.config.UI.SupportBannerDismissed)
 
 	// Attempt to load HMAC secret from vault (encrypted storage).
 	secretFromVault := a.vault.GetSecret("audit.secret_key")
@@ -1030,17 +1030,18 @@ func (a *App) SetLanguage(lang string) error {
 // not yet dismissed the banner.
 func (a *App) GetSupportBannerVisible() bool {
 	const threshold = 10
-	return a.config.LaunchCount >= threshold && !a.config.SupportBannerDismissed
+	return a.config.UI.UnlockCount >= threshold && !a.config.UI.SupportBannerDismissed
 }
 
 // DismissSupportBanner marks the support banner as permanently dismissed and
 // persists the state to tegata.toml.
 func (a *App) DismissSupportBanner() error {
-	a.config.SupportBannerDismissed = true
-	if a.vaultPath != "" {
-		if err := config.WriteUI(vaultDir(a.vaultPath), a.config.LaunchCount, true); err != nil {
-			return fmt.Errorf("saving support banner state: %w", err)
-		}
+	a.config.UI.SupportBannerDismissed = true
+	if a.vaultPath == "" {
+		return fmt.Errorf("vault is not open")
+	}
+	if err := config.WriteUI(vaultDir(a.vaultPath), a.config.UI.UnlockCount, true); err != nil {
+		return fmt.Errorf("saving support banner state: %w", err)
 	}
 	return nil
 }

--- a/cmd/tegata-gui/app.go
+++ b/cmd/tegata-gui/app.go
@@ -211,6 +211,10 @@ func (a *App) UnlockVault(path, passphrase string) error {
 	}
 	a.config = cfg
 
+	// Increment unlock count for the support banner threshold; failure is non-fatal.
+	a.config.LaunchCount++
+	_ = config.WriteUI(vaultDir(a.vaultPath), a.config.LaunchCount, a.config.SupportBannerDismissed)
+
 	// Attempt to load HMAC secret from vault (encrypted storage).
 	secretFromVault := a.vault.GetSecret("audit.secret_key")
 
@@ -1016,6 +1020,26 @@ func (a *App) SetLanguage(lang string) error {
 	if a.vaultPath != "" {
 		if err := config.WriteLanguage(vaultDir(a.vaultPath), lang); err != nil {
 			return fmt.Errorf("saving language: %w", err)
+		}
+	}
+	return nil
+}
+
+// GetSupportBannerVisible returns true when the one-time support banner should
+// be displayed: the vault has been unlocked at least 10 times and the user has
+// not yet dismissed the banner.
+func (a *App) GetSupportBannerVisible() bool {
+	const threshold = 10
+	return a.config.LaunchCount >= threshold && !a.config.SupportBannerDismissed
+}
+
+// DismissSupportBanner marks the support banner as permanently dismissed and
+// persists the state to tegata.toml.
+func (a *App) DismissSupportBanner() error {
+	a.config.SupportBannerDismissed = true
+	if a.vaultPath != "" {
+		if err := config.WriteUI(vaultDir(a.vaultPath), a.config.LaunchCount, true); err != nil {
+			return fmt.Errorf("saving support banner state: %w", err)
 		}
 	}
 	return nil

--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { UnlockView } from "@/components/vault/UnlockView"
 import { SetupWizard } from "@/components/vault/SetupWizard"
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner"
 import { ErrorBoundary } from "@/components/shared/ErrorBoundary"
+import { SupportBanner } from "@/components/shared/SupportBanner"
 import { useVault } from "@/hooks/useVault"
 import { useCredentials } from "@/hooks/useCredentials"
 import { useIdleTimer } from "@/hooks/useIdleTimer"
@@ -35,6 +36,7 @@ function App() {
   const [isSwitching, setIsSwitching] = useState(false)
   const [idleTimeoutMs, setIdleTimeoutMs] = useState(5 * 60 * 1000)
   const [auditEnabled, setAuditEnabled] = useState(false)
+  const [showSupportBanner, setShowSupportBanner] = useState(false)
 
   useEffect(() => {
     if (!vault.isUnlocked) return
@@ -66,9 +68,21 @@ function App() {
     }
   }, [vault.isUnlocked])
 
+  useEffect(() => {
+    if (!vault.isUnlocked) return
+    WailsApp.GetSupportBannerVisible()
+      .then(setShowSupportBanner)
+      .catch(() => {})
+  }, [vault.isUnlocked])
+
   const handleLock = useCallback(() => {
     vault.lock()
   }, [vault])
+
+  const handleDismissSupportBanner = useCallback(() => {
+    setShowSupportBanner(false)
+    WailsApp.DismissSupportBanner().catch(() => {})
+  }, [])
 
   // Only run the idle timer while the vault is unlocked. Passing 0 when the
   // user is on the setup or unlock screen disables the timer so pre-login
@@ -208,6 +222,8 @@ function App() {
           auditEnabled={auditEnabled}
         />
       </div>
+
+      {showSupportBanner && <SupportBanner onDismiss={handleDismissSupportBanner} />}
 
       <AddCredentialDialog
         open={addDialogOpen}

--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -81,6 +81,10 @@ function App() {
 
   const handleDismissSupportBanner = useCallback(() => {
     setShowSupportBanner(false)
+  }, [])
+
+  const handleDismissSupportBannerPermanently = useCallback(() => {
+    setShowSupportBanner(false)
     WailsApp.DismissSupportBanner().catch(console.error)
   }, [])
 
@@ -223,7 +227,7 @@ function App() {
         />
       </div>
 
-      {showSupportBanner && <SupportBanner onDismiss={handleDismissSupportBanner} />}
+      {showSupportBanner && <SupportBanner onDismiss={handleDismissSupportBanner} onDismissPermanently={handleDismissSupportBannerPermanently} />}
 
       <AddCredentialDialog
         open={addDialogOpen}

--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -72,7 +72,7 @@ function App() {
     if (!vault.isUnlocked) return
     WailsApp.GetSupportBannerVisible()
       .then(setShowSupportBanner)
-      .catch(() => {})
+      .catch(console.error)
   }, [vault.isUnlocked])
 
   const handleLock = useCallback(() => {

--- a/cmd/tegata-gui/frontend/src/App.tsx
+++ b/cmd/tegata-gui/frontend/src/App.tsx
@@ -81,7 +81,7 @@ function App() {
 
   const handleDismissSupportBanner = useCallback(() => {
     setShowSupportBanner(false)
-    WailsApp.DismissSupportBanner().catch(() => {})
+    WailsApp.DismissSupportBanner().catch(console.error)
   }, [])
 
   // Only run the idle timer while the vault is unlocked. Passing 0 when the

--- a/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
+++ b/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
@@ -9,13 +9,9 @@ import { useTheme } from "@/hooks/useTheme"
 import { App } from "@/lib/wails"
 import type { UpdateInfo } from "@/lib/types"
 import { cn, formatError } from "@/lib/utils"
-import { DISMISS_OPTIONS } from "@/lib/constants"
-import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime"
-
-const GITHUB_SPONSORS_URL = "https://github.com/sponsors/josh-wong"
-const KO_FI_URL = "https://ko-fi.com/josh_haha"
-const PAYPAL_URL = "https://www.paypal.me/joshww"
+import { DISMISS_OPTIONS, SUPPORT_URLS } from "@/lib/constants"
 import { SUPPORTED_LANGUAGES } from "@/lib/i18n"
+import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime"
 
 interface SettingsPanelProps {
   open: boolean
@@ -504,21 +500,21 @@ export function SettingsPanel({ open, onClose, onCredentialsChanged, updateInfo,
             <Button
               variant="outline"
               size="sm"
-              onClick={() => BrowserOpenURL(GITHUB_SPONSORS_URL)}
+              onClick={() => BrowserOpenURL(SUPPORT_URLS.gitHubSponsors)}
             >
               {t("gui.settings.supportGitHubSponsors")}
             </Button>
             <Button
               variant="outline"
               size="sm"
-              onClick={() => BrowserOpenURL(KO_FI_URL)}
+              onClick={() => BrowserOpenURL(SUPPORT_URLS.koFi)}
             >
               {t("gui.settings.supportKoFi")}
             </Button>
             <Button
               variant="outline"
               size="sm"
-              onClick={() => BrowserOpenURL(PAYPAL_URL)}
+              onClick={() => BrowserOpenURL(SUPPORT_URLS.payPal)}
             >
               {t("gui.settings.supportPayPal")}
             </Button>

--- a/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
+++ b/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
@@ -11,6 +11,10 @@ import type { UpdateInfo } from "@/lib/types"
 import { cn, formatError } from "@/lib/utils"
 import { DISMISS_OPTIONS } from "@/lib/constants"
 import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime"
+
+const GITHUB_SPONSORS_URL = "https://github.com/sponsors/josh-wong"
+const KO_FI_URL = "https://ko-fi.com/josh_haha"
+const PAYPAL_URL = "https://www.paypal.me/joshww"
 import { SUPPORTED_LANGUAGES } from "@/lib/i18n"
 
 interface SettingsPanelProps {
@@ -500,26 +504,27 @@ export function SettingsPanel({ open, onClose, onCredentialsChanged, updateInfo,
             <Button
               variant="outline"
               size="sm"
-              onClick={() => BrowserOpenURL(t("gui.settings.supportGitHubSponsorsUrl"))}
+              onClick={() => BrowserOpenURL(GITHUB_SPONSORS_URL)}
             >
               {t("gui.settings.supportGitHubSponsors")}
             </Button>
             <Button
               variant="outline"
               size="sm"
-              onClick={() => BrowserOpenURL(t("gui.settings.supportKoFiUrl"))}
+              onClick={() => BrowserOpenURL(KO_FI_URL)}
             >
               {t("gui.settings.supportKoFi")}
             </Button>
             <Button
               variant="outline"
               size="sm"
-              onClick={() => BrowserOpenURL(t("gui.settings.supportPayPalUrl"))}
+              onClick={() => BrowserOpenURL(PAYPAL_URL)}
             >
               {t("gui.settings.supportPayPal")}
             </Button>
           </div>
         </section>
+
         </div>
       </div>
     </div>

--- a/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
+++ b/cmd/tegata-gui/frontend/src/components/settings/SettingsPanel.tsx
@@ -489,6 +489,37 @@ export function SettingsPanel({ open, onClose, onCredentialsChanged, updateInfo,
             {t("gui.settings.privacyAndDisclaimer")}
           </Button>
         </section>
+
+        <Separator className="my-4" />
+
+        {/* Support */}
+        <section className="space-y-2">
+          <h3 className="text-sm font-medium">{t("gui.settings.sectionSupport")}</h3>
+          <p className="text-xs text-muted-foreground">{t("gui.settings.supportDescription")}</p>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => BrowserOpenURL(t("gui.settings.supportGitHubSponsorsUrl"))}
+            >
+              {t("gui.settings.supportGitHubSponsors")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => BrowserOpenURL(t("gui.settings.supportKoFiUrl"))}
+            >
+              {t("gui.settings.supportKoFi")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => BrowserOpenURL(t("gui.settings.supportPayPalUrl"))}
+            >
+              {t("gui.settings.supportPayPal")}
+            </Button>
+          </div>
+        </section>
         </div>
       </div>
     </div>

--- a/cmd/tegata-gui/frontend/src/components/shared/SupportBanner.tsx
+++ b/cmd/tegata-gui/frontend/src/components/shared/SupportBanner.tsx
@@ -1,0 +1,35 @@
+import { X } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { Button } from "@/components/ui/button"
+import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime"
+
+interface SupportBannerProps {
+  onDismiss: () => void
+}
+
+export function SupportBanner({ onDismiss }: SupportBannerProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-center gap-3 border-t bg-muted/50 px-4 py-2 text-sm">
+      <span className="shrink-0 text-muted-foreground">{t("gui.settings.supportBannerMessage")}</span>
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(t("gui.settings.supportGitHubSponsorsUrl"))}>
+          {t("gui.settings.supportGitHubSponsors")}
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(t("gui.settings.supportKoFiUrl"))}>
+          {t("gui.settings.supportKoFi")}
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(t("gui.settings.supportPayPalUrl"))}>
+          {t("gui.settings.supportPayPal")}
+        </Button>
+      </div>
+      <button
+        className="ml-auto shrink-0 text-muted-foreground hover:text-foreground"
+        onClick={onDismiss}
+        aria-label={t("gui.common.cancel")}
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/cmd/tegata-gui/frontend/src/components/shared/SupportBanner.tsx
+++ b/cmd/tegata-gui/frontend/src/components/shared/SupportBanner.tsx
@@ -3,6 +3,10 @@ import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime"
 
+const GITHUB_SPONSORS_URL = "https://github.com/sponsors/josh-wong"
+const KO_FI_URL = "https://ko-fi.com/josh_haha"
+const PAYPAL_URL = "https://www.paypal.me/joshww"
+
 interface SupportBannerProps {
   onDismiss: () => void
 }
@@ -13,20 +17,20 @@ export function SupportBanner({ onDismiss }: SupportBannerProps) {
     <div className="flex items-center gap-3 border-t bg-muted/50 px-4 py-2 text-sm">
       <span className="shrink-0 text-muted-foreground">{t("gui.settings.supportBannerMessage")}</span>
       <div className="flex flex-wrap gap-2">
-        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(t("gui.settings.supportGitHubSponsorsUrl"))}>
+        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(GITHUB_SPONSORS_URL)}>
           {t("gui.settings.supportGitHubSponsors")}
         </Button>
-        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(t("gui.settings.supportKoFiUrl"))}>
+        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(KO_FI_URL)}>
           {t("gui.settings.supportKoFi")}
         </Button>
-        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(t("gui.settings.supportPayPalUrl"))}>
+        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(PAYPAL_URL)}>
           {t("gui.settings.supportPayPal")}
         </Button>
       </div>
       <button
         className="ml-auto shrink-0 text-muted-foreground hover:text-foreground"
         onClick={onDismiss}
-        aria-label={t("gui.common.cancel")}
+        aria-label={t("gui.common.dismiss")}
       >
         <X className="h-4 w-4" />
       </button>

--- a/cmd/tegata-gui/frontend/src/components/shared/SupportBanner.tsx
+++ b/cmd/tegata-gui/frontend/src/components/shared/SupportBanner.tsx
@@ -1,11 +1,8 @@
 import { X } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
+import { SUPPORT_URLS } from "@/lib/constants"
 import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime"
-
-const GITHUB_SPONSORS_URL = "https://github.com/sponsors/josh-wong"
-const KO_FI_URL = "https://ko-fi.com/josh_haha"
-const PAYPAL_URL = "https://www.paypal.me/joshww"
 
 interface SupportBannerProps {
   onDismiss: () => void
@@ -18,26 +15,28 @@ export function SupportBanner({ onDismiss, onDismissPermanently }: SupportBanner
     <div className="flex items-center gap-3 border-t bg-muted/50 px-4 py-2 text-sm">
       <span className="shrink-0 text-muted-foreground">{t("gui.settings.supportBannerMessage")}</span>
       <div className="flex flex-wrap gap-2">
-        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(GITHUB_SPONSORS_URL)}>
+        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(SUPPORT_URLS.gitHubSponsors)}>
           {t("gui.settings.supportGitHubSponsors")}
         </Button>
-        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(KO_FI_URL)}>
+        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(SUPPORT_URLS.koFi)}>
           {t("gui.settings.supportKoFi")}
         </Button>
-        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(PAYPAL_URL)}>
+        <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(SUPPORT_URLS.payPal)}>
           {t("gui.settings.supportPayPal")}
         </Button>
         <Button variant="ghost" size="sm" onClick={onDismissPermanently}>
           {t("gui.settings.supportBannerDontShowAgain")}
         </Button>
       </div>
-      <button
-        className="ml-auto shrink-0 text-muted-foreground hover:text-foreground"
+      <Button
+        variant="ghost"
+        size="sm"
+        className="ml-auto shrink-0"
         onClick={onDismiss}
         aria-label={t("gui.common.dismiss")}
       >
         <X className="h-4 w-4" />
-      </button>
+      </Button>
     </div>
   )
 }

--- a/cmd/tegata-gui/frontend/src/components/shared/SupportBanner.tsx
+++ b/cmd/tegata-gui/frontend/src/components/shared/SupportBanner.tsx
@@ -9,9 +9,10 @@ const PAYPAL_URL = "https://www.paypal.me/joshww"
 
 interface SupportBannerProps {
   onDismiss: () => void
+  onDismissPermanently: () => void
 }
 
-export function SupportBanner({ onDismiss }: SupportBannerProps) {
+export function SupportBanner({ onDismiss, onDismissPermanently }: SupportBannerProps) {
   const { t } = useTranslation()
   return (
     <div className="flex items-center gap-3 border-t bg-muted/50 px-4 py-2 text-sm">
@@ -25,6 +26,9 @@ export function SupportBanner({ onDismiss }: SupportBannerProps) {
         </Button>
         <Button variant="outline" size="sm" onClick={() => BrowserOpenURL(PAYPAL_URL)}>
           {t("gui.settings.supportPayPal")}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onDismissPermanently}>
+          {t("gui.settings.supportBannerDontShowAgain")}
         </Button>
       </div>
       <button

--- a/cmd/tegata-gui/frontend/src/lib/constants.ts
+++ b/cmd/tegata-gui/frontend/src/lib/constants.ts
@@ -1,3 +1,9 @@
+export const SUPPORT_URLS = {
+  gitHubSponsors: "https://github.com/sponsors/josh-wong",
+  koFi: "https://ko-fi.com/josh_haha",
+  payPal: "https://www.paypal.me/joshww",
+} as const
+
 export const DOCUMENTATION_URLS = {
   privacyAndDisclaimer: "https://tegata.080f53.com/docs/privacy-and-disclaimer/",
 } as const

--- a/cmd/tegata-gui/frontend/src/lib/wails.ts
+++ b/cmd/tegata-gui/frontend/src/lib/wails.ts
@@ -82,6 +82,8 @@ interface WailsAppBindings {
   EnableAudit(): Promise<void>
   GetLanguage(): Promise<string>
   SetLanguage(lang: string): Promise<void>
+  GetSupportBannerVisible(): Promise<boolean>
+  DismissSupportBanner(): Promise<void>
 }
 
 function getApp(): WailsAppBindings {
@@ -142,6 +144,8 @@ export const App = {
   EnableAudit: () => getApp().EnableAudit(),
   GetLanguage: () => getApp().GetLanguage(),
   SetLanguage: (lang: string) => getApp().SetLanguage(lang),
+  GetSupportBannerVisible: () => getApp().GetSupportBannerVisible(),
+  DismissSupportBanner: () => getApp().DismissSupportBanner(),
 }
 
 export function EventsOn(event: string, callback: (...data: unknown[]) => void) {

--- a/cmd/tegata-gui/frontend/src/locales/en-us.json
+++ b/cmd/tegata-gui/frontend/src/locales/en-us.json
@@ -2,6 +2,7 @@
   "gui": {
     "common": {
       "cancel": "Cancel",
+      "dismiss": "Dismiss",
       "save": "Save",
       "done": "Done",
       "back": "Back",
@@ -279,11 +280,8 @@
       "supportBannerMessage": "Enjoying Tegata? Consider supporting the project:",
       "supportDescription": "If you find Tegata useful, consider supporting its development.",
       "supportGitHubSponsors": "GitHub Sponsors",
-      "supportGitHubSponsorsUrl": "https://github.com/sponsors/josh-wong",
       "supportKoFi": "Ko-fi",
-      "supportKoFiUrl": "https://ko-fi.com/josh_haha",
-      "supportPayPal": "PayPal",
-      "supportPayPalUrl": "https://www.paypal.me/joshww"
+      "supportPayPal": "PayPal"
     },
     "audit": {
       "title": "Audit",

--- a/cmd/tegata-gui/frontend/src/locales/en-us.json
+++ b/cmd/tegata-gui/frontend/src/locales/en-us.json
@@ -274,7 +274,16 @@
       "aboutVersion": "Version: {{version}}",
       "aboutLicense": "License: MIT",
       "privacyAndDisclaimer": "Privacy & disclaimer",
-      "privacyAndDisclaimerUrl": "https://tegata.080f53.com/docs/privacy-and-disclaimer/"
+      "privacyAndDisclaimerUrl": "https://tegata.080f53.com/docs/privacy-and-disclaimer/",
+      "sectionSupport": "Support the project",
+      "supportBannerMessage": "Enjoying Tegata? Consider supporting the project:",
+      "supportDescription": "If you find Tegata useful, consider supporting its development.",
+      "supportGitHubSponsors": "GitHub Sponsors",
+      "supportGitHubSponsorsUrl": "https://github.com/sponsors/josh-wong",
+      "supportKoFi": "Ko-fi",
+      "supportKoFiUrl": "https://ko-fi.com/josh_haha",
+      "supportPayPal": "PayPal",
+      "supportPayPalUrl": "https://www.paypal.me/joshww"
     },
     "audit": {
       "title": "Audit",

--- a/cmd/tegata-gui/frontend/src/locales/en-us.json
+++ b/cmd/tegata-gui/frontend/src/locales/en-us.json
@@ -278,6 +278,7 @@
       "privacyAndDisclaimerUrl": "https://tegata.080f53.com/docs/privacy-and-disclaimer/",
       "sectionSupport": "Support the project",
       "supportBannerMessage": "Enjoying Tegata? Consider supporting the project:",
+      "supportBannerDontShowAgain": "Don't show again",
       "supportDescription": "If you find Tegata useful, consider supporting its development.",
       "supportGitHubSponsors": "GitHub Sponsors",
       "supportKoFi": "Ko-fi",

--- a/cmd/tegata-gui/frontend/src/locales/ja-jp.json
+++ b/cmd/tegata-gui/frontend/src/locales/ja-jp.json
@@ -274,7 +274,16 @@
       "aboutVersion": "バージョン: {{version}}",
       "aboutLicense": "ライセンス: MIT",
       "privacyAndDisclaimer": "プライバシーと免責事項",
-      "privacyAndDisclaimerUrl": "https://tegata.080f53.com/ja-jp/docs/privacy-and-disclaimer/"
+      "privacyAndDisclaimerUrl": "https://tegata.080f53.com/ja-jp/docs/privacy-and-disclaimer/",
+      "sectionSupport": "プロジェクトを支援する",
+      "supportBannerMessage": "Tegataはお役に立てていますか？プロジェクトの支援をご検討ください：",
+      "supportDescription": "Tegataが役に立っている場合は、開発を支援することをご検討ください。",
+      "supportGitHubSponsors": "GitHub Sponsors",
+      "supportGitHubSponsorsUrl": "https://github.com/sponsors/josh-wong",
+      "supportKoFi": "Ko-fi",
+      "supportKoFiUrl": "https://ko-fi.com/josh_haha",
+      "supportPayPal": "PayPal",
+      "supportPayPalUrl": "https://www.paypal.me/joshww"
     },
     "audit": {
       "title": "監査",

--- a/cmd/tegata-gui/frontend/src/locales/ja-jp.json
+++ b/cmd/tegata-gui/frontend/src/locales/ja-jp.json
@@ -2,6 +2,7 @@
   "gui": {
     "common": {
       "cancel": "キャンセル",
+      "dismiss": "閉じる",
       "save": "保存",
       "done": "完了",
       "back": "戻る",
@@ -279,11 +280,8 @@
       "supportBannerMessage": "Tegataはお役に立てていますか？プロジェクトの支援をご検討ください：",
       "supportDescription": "Tegataが役に立っている場合は、開発を支援することをご検討ください。",
       "supportGitHubSponsors": "GitHub Sponsors",
-      "supportGitHubSponsorsUrl": "https://github.com/sponsors/josh-wong",
       "supportKoFi": "Ko-fi",
-      "supportKoFiUrl": "https://ko-fi.com/josh_haha",
-      "supportPayPal": "PayPal",
-      "supportPayPalUrl": "https://www.paypal.me/joshww"
+      "supportPayPal": "PayPal"
     },
     "audit": {
       "title": "監査",

--- a/cmd/tegata-gui/frontend/src/locales/ja-jp.json
+++ b/cmd/tegata-gui/frontend/src/locales/ja-jp.json
@@ -277,8 +277,9 @@
       "privacyAndDisclaimer": "プライバシーと免責事項",
       "privacyAndDisclaimerUrl": "https://tegata.080f53.com/ja-jp/docs/privacy-and-disclaimer/",
       "sectionSupport": "プロジェクトを支援する",
-      "supportBannerMessage": "Tegataはお役に立てていますか？プロジェクトの支援をご検討ください：",
-      "supportDescription": "Tegataが役に立っている場合は、開発を支援することをご検討ください。",
+      "supportBannerMessage": "Tegata はお役に立てていますか？プロジェクトの支援をご検討ください:",
+      "supportBannerDontShowAgain": "今後表示しない",
+      "supportDescription": "Tegata が役に立っている場合は、開発を支援することをご検討ください。",
       "supportGitHubSponsors": "GitHub Sponsors",
       "supportKoFi": "Ko-fi",
       "supportPayPal": "PayPal"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,12 +25,15 @@ type Config struct {
 	UI UIConfig
 }
 
-// UIConfig holds UI-layer state persisted in the [ui] section of tegata.toml.
+// UIConfig holds UI-layer state. SupportBannerDismissed is persisted in the
+// [ui] section of tegata.toml. UnlockCount is stored in the encrypted vault
+// (not in tegata.toml) so it cannot be casually manipulated.
 type UIConfig struct {
-	// UnlockCount tracks how many times the vault has been unlocked. Used to
-	// decide when to show the one-time support banner.
+	// UnlockCount is loaded from the encrypted vault on unlock and held in
+	// memory only. It is never written to tegata.toml.
 	UnlockCount int
-	// SupportBannerDismissed is true once the user has dismissed the banner.
+	// SupportBannerDismissed is true once the user has permanently dismissed
+	// the support banner. Persisted to tegata.toml.
 	SupportBannerDismissed bool
 }
 
@@ -105,7 +108,6 @@ type tomlAuditConfig struct {
 // tomlConfig is the intermediate deserialization struct. Pointer fields
 // distinguish "not set" from "zero value".
 type tomlUI struct {
-	UnlockCount            *int  `toml:"unlock_count"`
 	SupportBannerDismissed *bool `toml:"support_banner_dismissed"`
 }
 
@@ -224,9 +226,6 @@ func Load(dir string) (Config, error) {
 		cfg.Audit.AutoStart = true
 	}
 
-	if tc.UI.UnlockCount != nil {
-		cfg.UI.UnlockCount = *tc.UI.UnlockCount
-	}
 	if tc.UI.SupportBannerDismissed != nil {
 		cfg.UI.SupportBannerDismissed = *tc.UI.SupportBannerDismissed
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,11 @@ type Config struct {
 	// Audit holds optional ScalarDL Ledger integration settings. When
 	// Audit.Enabled is false (the default) the audit layer is inactive.
 	Audit AuditConfig
+	// LaunchCount tracks how many times the vault has been unlocked. Used to
+	// decide when to show the one-time support banner.
+	LaunchCount int
+	// SupportBannerDismissed is true once the user has dismissed the banner.
+	SupportBannerDismissed bool
 }
 
 // AuditConfig holds settings for the optional ScalarDL Ledger audit layer.
@@ -93,6 +98,11 @@ type tomlAuditConfig struct {
 
 // tomlConfig is the intermediate deserialization struct. Pointer fields
 // distinguish "not set" from "zero value".
+type tomlUI struct {
+	LaunchCount            *int  `toml:"launch_count"`
+	SupportBannerDismissed *bool `toml:"support_banner_dismissed"`
+}
+
 type tomlConfig struct {
 	Language  *string `toml:"language"`
 	Clipboard struct {
@@ -102,6 +112,7 @@ type tomlConfig struct {
 		IdleTimeout *int `toml:"idle_timeout"`
 	} `toml:"vault"`
 	Audit tomlAuditConfig `toml:"audit"`
+	UI    tomlUI          `toml:"ui"`
 }
 
 const (
@@ -205,6 +216,13 @@ func Load(dir string) (Config, error) {
 	// When docker_compose_path is set but auto_start is absent, default to true.
 	if a.AutoStart == nil && cfg.Audit.DockerComposePath != "" {
 		cfg.Audit.AutoStart = true
+	}
+
+	if tc.UI.LaunchCount != nil {
+		cfg.LaunchCount = *tc.UI.LaunchCount
+	}
+	if tc.UI.SupportBannerDismissed != nil {
+		cfg.SupportBannerDismissed = *tc.UI.SupportBannerDismissed
 	}
 
 	return cfg, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,9 +21,15 @@ type Config struct {
 	// Audit holds optional ScalarDL Ledger integration settings. When
 	// Audit.Enabled is false (the default) the audit layer is inactive.
 	Audit AuditConfig
-	// LaunchCount tracks how many times the vault has been unlocked. Used to
+	// UI holds UI-layer state that travels with the vault on USB.
+	UI UIConfig
+}
+
+// UIConfig holds UI-layer state persisted in the [ui] section of tegata.toml.
+type UIConfig struct {
+	// UnlockCount tracks how many times the vault has been unlocked. Used to
 	// decide when to show the one-time support banner.
-	LaunchCount int
+	UnlockCount int
 	// SupportBannerDismissed is true once the user has dismissed the banner.
 	SupportBannerDismissed bool
 }
@@ -99,7 +105,7 @@ type tomlAuditConfig struct {
 // tomlConfig is the intermediate deserialization struct. Pointer fields
 // distinguish "not set" from "zero value".
 type tomlUI struct {
-	LaunchCount            *int  `toml:"launch_count"`
+	UnlockCount            *int  `toml:"unlock_count"`
 	SupportBannerDismissed *bool `toml:"support_banner_dismissed"`
 }
 
@@ -218,11 +224,11 @@ func Load(dir string) (Config, error) {
 		cfg.Audit.AutoStart = true
 	}
 
-	if tc.UI.LaunchCount != nil {
-		cfg.LaunchCount = *tc.UI.LaunchCount
+	if tc.UI.UnlockCount != nil {
+		cfg.UI.UnlockCount = *tc.UI.UnlockCount
 	}
 	if tc.UI.SupportBannerDismissed != nil {
-		cfg.SupportBannerDismissed = *tc.UI.SupportBannerDismissed
+		cfg.UI.SupportBannerDismissed = *tc.UI.SupportBannerDismissed
 	}
 
 	return cfg, nil

--- a/internal/config/write_ui.go
+++ b/internal/config/write_ui.go
@@ -8,14 +8,16 @@ import (
 
 // WriteUI writes or replaces the [ui] section in tegata.toml located in dir.
 // All other content is preserved. If tegata.toml does not exist, it is created.
-func WriteUI(dir string, unlockCount int, bannerDismissed bool) error {
+// Only the support banner dismissal state is stored here; the unlock count is
+// kept in the encrypted vault and never written to tegata.toml.
+func WriteUI(dir string, bannerDismissed bool) error {
 	path := filepath.Join(dir, configFileName)
 	existing, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	block := fmt.Sprintf("[ui]\nunlock_count = %d\nsupport_banner_dismissed = %t\n", unlockCount, bannerDismissed)
+	block := fmt.Sprintf("[ui]\nsupport_banner_dismissed = %t\n", bannerDismissed)
 	content := rewriteSection(existing, "ui", block)
 	return os.WriteFile(path, []byte(content), 0600)
 }

--- a/internal/config/write_ui.go
+++ b/internal/config/write_ui.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteUI writes or replaces the [ui] section in tegata.toml located in dir.
+// All other content is preserved. If tegata.toml does not exist, it is created.
+func WriteUI(dir string, launchCount int, bannerDismissed bool) error {
+	path := filepath.Join(dir, configFileName)
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	block := fmt.Sprintf("[ui]\nlaunch_count = %d\nsupport_banner_dismissed = %t\n", launchCount, bannerDismissed)
+	content := rewriteSection(existing, "ui", block)
+	return os.WriteFile(path, []byte(content), 0600)
+}

--- a/internal/config/write_ui.go
+++ b/internal/config/write_ui.go
@@ -8,14 +8,14 @@ import (
 
 // WriteUI writes or replaces the [ui] section in tegata.toml located in dir.
 // All other content is preserved. If tegata.toml does not exist, it is created.
-func WriteUI(dir string, launchCount int, bannerDismissed bool) error {
+func WriteUI(dir string, unlockCount int, bannerDismissed bool) error {
 	path := filepath.Join(dir, configFileName)
 	existing, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	block := fmt.Sprintf("[ui]\nlaunch_count = %d\nsupport_banner_dismissed = %t\n", launchCount, bannerDismissed)
+	block := fmt.Sprintf("[ui]\nunlock_count = %d\nsupport_banner_dismissed = %t\n", unlockCount, bannerDismissed)
 	content := rewriteSection(existing, "ui", block)
 	return os.WriteFile(path, []byte(content), 0600)
 }


### PR DESCRIPTION
## Summary

This PR adds a "Support the project" section to the settings panel with clickable buttons for GitHub Sponsors, Ko-fi, and PayPal. It also adds a support banner that appears at the bottom of the main view every 10 vault unlocks, which users can permanently dismiss. The unlock count is stored in the encrypted vault and the dismissal state is persisted in `tegata.toml`.

## Related issues or PRs

- Resolves #139

## Changes made

- Added "Support the project" section to the settings panel with buttons for GitHub Sponsors, Ko-fi, and PayPal
- Added a `SupportBanner` component that appears at the bottom of the main view every 10 vault unlocks until permanently dismissed
- Added `UnlockCount` and `SupportBannerDismissed` fields to `UIConfig`; unlock count is stored in the encrypted vault, dismissal state is persisted in `tegata.toml` via a new `[ui]` section
- Added `GetSupportBannerVisible()` and `DismissSupportBanner()` app methods
- Added i18n strings for the support section and banner in English and Japanese
- Extracted support URLs to a shared `SUPPORT_URLS` constant in `constants.ts`

## Technical implementation

- **Approach:** The unlock count is stored in the encrypted vault (not `tegata.toml`) so it cannot be manipulated by editing the config file. The dismissal state is written to a new `[ui]` section of `tegata.toml`, which travels with the vault on USB so it persists across machines.
- **Key components modified:** `internal/config/config.go`, `cmd/tegata-gui/app.go`, `SettingsPanel.tsx`, `SupportBanner.tsx`, `App.tsx`, `constants.ts`, both locale files
- **Dependencies added/removed:** None
- **Design patterns used:** Follows the existing `rewriteSection` pattern in the config package for the new `WriteUI()` helper; banner threshold is every 10 unlocks (gives users time to evaluate the app before seeing the prompt); support URLs centralized in `SUPPORT_URLS` constant shared between `SettingsPanel` and `SupportBanner`

## Testing performed

- [x] Builds successfully on macOS (arm64)
- [ ] Builds successfully on Windows (amd64)
- [ ] Builds successfully on Linux (amd64)
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] CLI commands tested manually with expected inputs
- [ ] Edge cases and error handling tested (invalid inputs, missing files, permission errors)
- [ ] Cryptographic operations verified (if applicable) — not applicable – no cryptographic operations involved
- [ ] ScalarDL integration tested (if applicable) — not applicable – no ScalarDL integration involved
- [ ] Cross-platform compatibility verified (if applicable)

## Security considerations

- [x] No sensitive data (keys, passwords, secrets) in code or tests
- [ ] Cryptographic operations use secure, well-tested libraries — not applicable – no cryptographic operations added
- [ ] Memory is zeroed after handling sensitive data — not applicable – no sensitive data handled
- [ ] Input validation implemented for all user-provided data — not applicable – support links are hardcoded URLs, no user input
- [x] No SQL injection, command injection, or path traversal vulnerabilities
- [x] Error messages don't leak sensitive information
- [x] Vault files remain encrypted and properly protected
- [x] No new dependencies with known vulnerabilities
- [ ] Authentication/authorization logic is sound (if applicable) — not applicable – no authentication/authorization logic changed

## Code quality

- [x] Code follows project conventions (Go style guidelines)
- [x] Added appropriate comments for complex cryptographic or security logic
- [x] No hardcoded secrets or configuration values
- [x] Proper error handling and user-friendly error messages
- [x] No debugging code or print/println statements left in
- [x] Removed unused imports, variables, and functions
- [x] Dependencies pinned to specific versions
- [ ] Documentation updated (README, user guides, API docs if applicable)

## Breaking changes

- [x] No breaking changes

## Additional context

The banner appears every 10 vault unlocks rather than only once, so users who dismiss it temporarily (via the X button) will see it again on their next 10th unlock. Clicking "Don't show again" permanently dismisses the banner by writing `support_banner_dismissed = true` to the `[ui]` section of `tegata.toml`. The unlock count is incremented on each `UnlockVault` call and stored in the encrypted vault — keeping it there prevents a user from resetting the counter by editing `tegata.toml`.